### PR TITLE
Add Palo Alto PAN-OS Firewall Sigma rules

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ActiveCampaign 1-2-All Admin Panel Username Parameter SQL Injection.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ActiveCampaign 1-2-All Admin Panel Username Parameter SQL Injection.yaml
@@ -1,0 +1,17 @@
+title: ActiveCampaign 1-2-All Admin Panel Username Parameter SQL Injection
+description: Palo Alto Networks detection for ActiveCampaign 1-2-All Admin Panel Username Parameter SQL Injection
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: ActiveCampaign 1-2-All Admin Panel Username Parameter SQL Injection*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz XXE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz XXE Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Apache OFBiz XXE Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz XXE Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Apache OFBiz XXE Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Apache Struts2 Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache Struts2 Code Execution Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Apache Struts2 Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Remote Code Execution Via JSP Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Remote Code Execution Via JSP Upload Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Apache Tomcat Remote Code Execution Via JSP Upload Vulnerability
+description: Palo Alto Networks detection for Apache Tomcat Remote Code Execution Via JSP Upload Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Apache Tomcat Remote Code Execution Via JSP Upload Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy cyrus.php Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy cyrus.php Command Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Artica Proxy cyrus.php Command Injection Vulnerability
+description: Palo Alto Networks detection for Artica Proxy cyrus.php Command Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Artica Proxy cyrus.php Command Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BE126 WIFI Local File Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BE126 WIFI Local File Disclosure Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: BE126 WIFI Local File Disclosure Vulnerability
+description: Palo Alto Networks detection for BE126 WIFI Local File Disclosure Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: BE126 WIFI Local File Disclosure Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CMS Made Simple SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CMS Made Simple SQL Injection Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: CMS Made Simple SQL Injection Vulnerability
+description: Palo Alto Networks detection for CMS Made Simple SQL Injection Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: CMS Made Simple SQL Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Smart Install Protocol Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Smart Install Protocol Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Smart Install Protocol Vulnerability
+description: Palo Alto Vulnerability detection - Cisco Smart Install Protocol Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Cisco Smart Install Protocol Vulnerability*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Elastic Elasticsearch Snapshot API Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Elastic Elasticsearch Snapshot API Directory Traversal Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Elastic Elasticsearch Snapshot API Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Elastic Elasticsearch Snapshot API Directory Traversal Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Elastic Elasticsearch Snapshot API Directory Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ffay Lanproxy Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ffay Lanproxy Directory Traversal Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Ffay Lanproxy Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Ffay Lanproxy Directory Traversal Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Ffay Lanproxy Directory Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/File detection - Unknown Binary File.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/File detection - Unknown Binary File.yaml
@@ -1,0 +1,16 @@
+title: File detection - Unknown Binary File
+description: Palo Alto File detection - Unknown Binary File
+tags:
+- mitre.t1071.001
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: file
+  rule:
+    ruleName: Unknown Binary File*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FineCMS Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FineCMS Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: FineCMS Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for FineCMS Remote Code Execution Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: FineCMS Remote Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ghost CMS Path Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ghost CMS Path Traversal Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Ghost CMS Path Traversal Vulnerability
+description: Palo Alto Networks detection for Ghost CMS Path Traversal Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Ghost CMS Path Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Grafana Labs Grafana Snapshot Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Grafana Labs Grafana Snapshot Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Grafana Labs Grafana Snapshot Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Grafana Labs Grafana Snapshot Authentication Bypass Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Grafana Labs Grafana Snapshot Authentication Bypass Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HP Enterprise VAN SDN Controller Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HP Enterprise VAN SDN Controller Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: HP Enterprise VAN SDN Controller Remote Command Execution Vulnerability
+description: Palo Alto Vulnerability detection - HP Enterprise VAN SDN Controller Remote Command Execution Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: HP Enterprise VAN SDN Controller Remote Command Execution Vulnerability*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HP Universal CMDB Server Credential Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HP Universal CMDB Server Credential Code Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: HP Universal CMDB Server Credential Code Execution Vulnerability
+description: Palo Alto Networks detection for HP Universal CMDB Server Credential Code Execution Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: HP Universal CMDB Server Credential Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP GET Requests Long URI Anomaly.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP GET Requests Long URI Anomaly.yaml
@@ -1,0 +1,16 @@
+title: HTTP GET Requests Long URI Anomaly
+description: Palo Alto Vulnerability detection - HTTP GET Requests Long URI Anomaly
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: HTTP GET Requests Long URI Anomaly*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP2 Protocol Suspicious RST STREAM Frame detection.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP2 Protocol Suspicious RST STREAM Frame detection.yaml
@@ -1,0 +1,16 @@
+title: HTTP2 Protocol Suspicious RST STREAM Frame detection
+description: Palo Alto Vulnerability detection - HTTP2 Protocol Suspicious RST STREAM Frame detection
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: HTTP2 Protocol Suspicious RST STREAM Frame detection*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Javascript WSF HTA JSE or VBS File Sent in Email.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Javascript WSF HTA JSE or VBS File Sent in Email.yaml
@@ -1,0 +1,16 @@
+title: Javascript WSF HTA JSE or VBS File Sent in Email
+description: Palo Alto Vulnerability detection - Javascript WSF HTA JSE or VBS File Sent in Email
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Javascript WSF HTA JSE or VBS File Sent in Email*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/JetBrains TeamCity Path Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/JetBrains TeamCity Path Traversal Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: JetBrains TeamCity Path Traversal Vulnerability
+description: Palo Alto Networks detection for JetBrains TeamCity Path Traversal Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: JetBrains TeamCity Path Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Jolokia Agent JNDI Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Jolokia Agent JNDI Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Jolokia Agent JNDI Injection Vulnerability
+description: Palo Alto Networks detection for Jolokia Agent JNDI Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Jolokia Agent JNDI Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Laravel Ignition Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Laravel Ignition Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Laravel Ignition Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Laravel Ignition Remote Code Execution Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Laravel Ignition Remote Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios SQL Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Nagios SQL Injection Vulnerability
+description: Palo Alto Networks detection for Nagios SQL Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Nagios SQL Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios XI SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios XI SQL Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Nagios XI SQL Injection Vulnerability
+description: Palo Alto Networks detection for Nagios XI SQL Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Nagios XI SQL Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear JNR1010 Path Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear JNR1010 Path Traversal Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Netgear JNR1010 Path Traversal Vulnerability
+description: Palo Alto Networks detection for Netgear JNR1010 Path Traversal Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Netgear JNR1010 Path Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Service Detection.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Service Detection.yaml
@@ -1,0 +1,16 @@
+title: Nmap Service Detection
+description: Palo Alto Vulnerability detection - Nmap Service Detection
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Nmap Service Detection*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenSSH Denial of Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenSSH Denial of Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: OpenSSH Denial of Service Vulnerability
+description: Palo Alto Vulnerability detection - OpenSSH Denial of Service Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: OpenSSH Denial of Service Vulnerability*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenSSL TLS Heartbleed Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenSSL TLS Heartbleed Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: OpenSSL TLS Heartbleed Vulnerability
+description: Palo Alto Vulnerability detection - OpenSSL TLS Heartbleed Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: OpenSSL TLS Heartbleed Vulnerability*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/PNG File Chunk Length Abnormal.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/PNG File Chunk Length Abnormal.yaml
@@ -1,0 +1,16 @@
+title: PNG File Chunk Length Abnormal
+description: Palo Alto Vulnerability detection - PNG File Chunk Length Abnormal
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: PNG File Chunk Length Abnormal*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Pentaho Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Pentaho Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Pentaho Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Pentaho Authentication Bypass Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Pentaho Authentication Bypass Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Potential HTML Evasion Technique Detected in HTTP Response.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Potential HTML Evasion Technique Detected in HTTP Response.yaml
@@ -1,0 +1,16 @@
+title: Potential HTML Evasion Technique Detected in HTTP Response
+description: Palo Alto Vulnerability detection - Potential HTML Evasion Technique Detected in HTTP Response
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Potential HTML Evasion Technique Detected in HTTP Response*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/RPC Portmapper DUMP Request Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/RPC Portmapper DUMP Request Detected.yaml
@@ -1,0 +1,16 @@
+title: RPC Portmapper DUMP Request Detected
+description: Palo Alto Vulnerability detection - RPC Portmapper DUMP Request Detected
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: RPC Portmapper DUMP Request Detected*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/SSH Failed Brute-force Authentication Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/SSH Failed Brute-force Authentication Attempt.yaml
@@ -1,0 +1,16 @@
+title: SSH Failed Brute-force Authentication Attempt
+description: Palo Alto Vulnerability detection - SSH Failed Brute-force Authentication Attempt
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: SSH Failed Brute-force Authentication Attempt*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/SSL Double Client Hello Cipher Suite Length Mismatch.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/SSL Double Client Hello Cipher Suite Length Mismatch.yaml
@@ -1,0 +1,16 @@
+title: SSL Double Client Hello Cipher Suite Length Mismatch
+description: Palo Alto Vulnerability detection - SSL Double Client Hello Cipher Suite Length Mismatch
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: SSL Double Client Hello Cipher Suite Length Mismatch*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Spring Boot Actuator Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Spring Boot Actuator Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Spring Boot Actuator Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Spring Boot Actuator Remote Code Execution Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Spring Boot Actuator Remote Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/TLS SNI Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/TLS SNI Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: TLS SNI Denial-of-Service Vulnerability
+description: Palo Alto Vulnerability detection - TLS SNI Denial-of-Service Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: TLS SNI Denial-of-Service Vulnerability*
+  condition: subname and rule and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ThinkPHP Arbitrary File Write Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ThinkPHP Arbitrary File Write Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ThinkPHP Arbitrary File Write Vulnerability
+description: Palo Alto Networks detection for ThinkPHP Arbitrary File Write Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: ThinkPHP Arbitrary File Write Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress LearnPress Plugin SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress LearnPress Plugin SQL Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: WordPress LearnPress Plugin SQL Injection Vulnerability
+description: Palo Alto Networks detection for WordPress LearnPress Plugin SQL Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: WordPress LearnPress Plugin SQL Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Plugin and Theme Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Plugin and Theme Directory Traversal Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: WordPress Plugin and Theme Directory Traversal Vulnerability
+description: Palo Alto Networks detection for WordPress Plugin and Theme Directory Traversal Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: WordPress Plugin and Theme Directory Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Video List Manager Plugin SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Video List Manager Plugin SQL Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: WordPress Video List Manager Plugin SQL Injection Vulnerability
+description: Palo Alto Networks detection for WordPress Video List Manager Plugin SQL Injection Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: WordPress Video List Manager Plugin SQL Injection Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zentao Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zentao Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Zentao Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Zentao Remote Code Execution Vulnerability
+tags:
+- mitre.t1190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: Zentao Remote Code Execution Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/aiohttp Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/aiohttp Directory Traversal Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Aiohttp Directory Traversal Vulnerability
+description: Palo Alto Networks detection for aiohttp Directory Traversal Vulnerability
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleName: aiohttp Directory Traversal Vulnerability*
+  severity:
+    severity: '8'
+  condition: subname and rule and severity and not action
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma detection rules for various vulnerabilities and anomalies in third-party applications and protocols, targeting Palo Alto Networks PAN-OS Firewall logs. These rules cover SQL injection, code execution, directory traversal, authentication bypass, and other security threats.