### PR TITLE
Add Palo Alto Networks PAN-OS firewall Sigma rules

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/.NET Remoting Validation Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/.NET Remoting Validation Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: .NET Remoting Validation Bypass Vulnerability
+description: Palo Alto Networks detection for .NET Remoting Validation Bypass Vulnerability. .NET Remoting is prone to a validation bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable validation bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.29059
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '96013'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/360 Skylar SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/360 Skylar SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: 360 Skylar SQL Injection Vulnerability
+description: Palo Alto Networks detection for 360 Skylar SQL Injection Vulnerability. 360 Skylar is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91185'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/7-Zip 7Z File PPMd Properties Parsing Integer Underflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/7-Zip 7Z File PPMd Properties Parsing Integer Underflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: 7-Zip 7Z File PPMd Properties Parsing Integer Underflow Vulnerability
+description: Palo Alto Networks detection for 7-Zip 7Z File PPMd Properties Parsing Integer Underflow Vulnerability. 7-Zip is prone to an integer underflow vulnerability while parsing certain crafted 7Z files. The vulnerability is due to the lack of proper checks on 7Z files, leading to an exploitable integer underflow vulnerability. An attacker could exploit the vulnerability by sending a crafted 7Z file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2023.31102
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95779'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/7-Zip SquashFS File Parsing Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/7-Zip SquashFS File Parsing Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: 7-Zip SquashFS File Parsing Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for 7-Zip SquashFS File Parsing Buffer Overflow Vulnerability. 7-Zip is prone to a buffer overflow vulnerability while parsing certain crafted squashfs files. The vulnerability is due to the lack of proper checks on squashfs files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted squashfs file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2023.40481
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95739'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/74CMS Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/74CMS Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: 74CMS Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for 74CMS Remote Code Execution Vulnerability. 74CMS is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.29279
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90855'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AD FS Secrets Stealing Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AD FS Secrets Stealing Discovery.yaml
@@ -1,0 +1,15 @@
+title: AD FS Secrets Stealing Discovery
+description: Palo Alto Networks detection for AD FS Secrets Stealing Detection. This signature detects AD FS replication messages which can be abused to steal secrets.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91120'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA CRLF Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA CRLF Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion FTA CRLF Injection Vulnerability
+description: Palo Alto Networks detection for Accellion FTA CRLF Injection Vulnerability. Accellion FTA is prone to a CRLF Injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP files, leading to an exploitable CRLF vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP requests. A successful attack could lead a CRLF Injection attack.
+tags:
+- cve.2017.8791
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90295'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA LDAP Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA LDAP Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion FTA LDAP Injection Vulnerability
+description: Palo Alto Networks detection for Accellion FTA LDAP Injection Vulnerability. Accellion FTA is prone to a LDAP Injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable LDAP Injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.8790
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90294'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion FTA Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Accellion FTA Remote Code Execution Vulnerability. Accellion FTA is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.8303
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90253'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA SQL Injection Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Accellion FTA SQL Injection Vulnerability
+description: Palo Alto Networks detection for Accellion FTA SQL Injection Vulnerability. Accellion FTA is prone to a SQL Injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL Injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.8789
+- cve.2017.8796
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90298'
+    - '90267'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA SSRF Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA SSRF Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion FTA SSRF Vulnerability
+description: Palo Alto Networks detection for Accellion FTA SSRF Vulnerability. Accellion FTA is prone to a SSRF vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SSRF vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.8794
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90297'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion FTA XSS Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: Accellion FTA XSS Vulnerability
+description: Palo Alto Networks detection for Accellion FTA XSS Vulnerability. Accellion FTA is prone to a XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.8304
+- cve.2017.8792
+- cve.2017.8795
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90296'
+    - '90252'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Arbitrary Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Arbitrary Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion File Transfer Appliance Arbitrary Code Execution Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance Arbitrary Code Execution Vulnerability. Accellion File Transfer Appliance is prone to a code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2015.2857
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90265'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion File Transfer Appliance Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance Directory Traversal Vulnerability. Accellion File Transfer Appliance is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2015.2856
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90262'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance MPIPE2 Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance MPIPE2 Command Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Accellion File Transfer Appliance MPIPE2 Command Execution Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance MPIPE2 Command Execution Vulnerability. Accellion File Transfer Appliance is prone to a code execution vulnerability while parsing certain crafted UDP requests. The vulnerability is due to the lack of proper checks on UDP requests, leading to an exploitable code execution vulnerability. An attacker could exploit the vulnerability by sending crafted UDP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2019.5622
+- cve.2019.5623
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90268'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Mail Relay Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance Mail Relay Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion File Transfer Appliance Mail Relay Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance Mail Relay Vulnerability. Accellion File Transfer Appliance is prone to a mail relay vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable mail relay vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote attackers to send spam e-mail.
+tags:
+- cve.2008.7012
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90251'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion File Transfer Appliance SQL Injection Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance SQL Injection Vulnerability. Accellion File Transfer Appliance is prone to an SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2016.2351
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90307'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion File Transfer Appliance XSS Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Accellion File Transfer Appliance XSS Vulnerability
+description: Palo Alto Networks detection for Accellion File Transfer Appliance Cross-Site Scripting Vulnerability. Accellion File Transfer Appliance is prone to an XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2008.3850
+- cve.2016.2350
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90249'
+    - '90306'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion Secure File Transfer Appliance Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accellion Secure File Transfer Appliance Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Accellion Secure File Transfer Appliance Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Accellion Secure File Transfer Appliance Directory Traversal Vulnerability. Accellion Secure File Transfer Appliance is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2009.4645
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90246'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accfly Wireless Security Camera Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Accfly Wireless Security Camera Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,23 @@
+title: Accfly Wireless Security Camera Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Accfly Wireless Security Camera Buffer Overflow Vulnerability. Accfly Wireless Security Camera is prone to a buffer overflow vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted TCP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.25783
+- cve.2020.25782
+- cve.2020.25784
+- cve.2020.25785
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90325'
+    - '90324'
+    - '90322'
+    - '90323'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,25 @@
+title: Acrobat Reader Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Buffer Overflow Vulnerability. Acrobat Reader is prone to a buffer overflow vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21046
+- cve.2021.21063
+- cve.2021.21062
+- cve.2021.21058
+- cve.2021.21059
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90362'
+    - '90366'
+    - '90378'
+    - '90360'
+    - '90373'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Acrobat Reader Code Execution Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Code Execution Vulnerability. Acrobat Reader is prone to a code execution vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21037
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90361'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader DC Out-of-bounds Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader DC Out-of-bounds Read Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Acrobat Reader DC Out-of-bounds Read Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader DC Out-of-bounds Read Vulnerability. Acrobat Reader DC is prone to an out-of-bounds read vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable out-of-bounds read vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2021.21042
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '91140'
+    - '91139'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Heap-Based Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Heap-Based Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Acrobat Reader Heap-Based Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Heap-Based Buffer Overflow Vulnerability. Acrobat Reader is prone to a heap-based buffer overflow vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable heap-based buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21017
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90367'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Integer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Integer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Acrobat Reader Integer Overflow Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Integer Overflow Vulnerability. Acrobat Reader is prone to an integer overflow vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable integer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21036
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90365'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Memory Corruption Vulnerability.yaml
@@ -1,0 +1,79 @@
+title: Acrobat Reader Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Memory Corruption Vulnerability. Acrobat Reader is prone to a memory corruption vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption condition with the privileges of the currently logged-in user.
+tags:
+- cve.2024.30312
+- cve.2024.30310
+- cve.2024.30284
+- cve.2024.41834
+- cve.2024.41832
+- cve.2024.39426
+- cve.2024.41833
+- cve.2024.41830
+- cve.2024.41835
+- cve.2024.39424
+- cve.2024.41831
+- cve.2024.39422
+- cve.2024.39423
+- cve.2024.39383
+- cve.2024.41869
+- cve.2024.39420
+- cve.2024.49530
+- cve.2024.49531
+- cve.2024.49534
+- cve.2024.49533
+- cve.2024.49535
+- cve.2024.49532
+- cve.2025.27162
+- cve.2025.27163
+- cve.2025.27164
+- cve.2025.27174
+- cve.2025.24431
+- cve.2025.27161
+- cve.2025.27160
+- cve.2025.27159
+- cve.2025.27158
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '96061'
+    - '96054'
+    - '95486'
+    - '95808'
+    - '96058'
+    - '95810'
+    - '95217'
+    - '95490'
+    - '95577'
+    - '95216'
+    - '95487'
+    - '96051'
+    - '95494'
+    - '96057'
+    - '95489'
+    - '96060'
+    - '95218'
+    - '96053'
+    - '95220'
+    - '95219'
+    - '95807'
+    - '95493'
+    - '95488'
+    - '95495'
+    - '95492'
+    - '95809'
+    - '95491'
+    - '96056'
+    - '95811'
+    - '95806'
+    - '96052'
+    - '95496'
+    - '95570'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Null Pointer Dereference Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Null Pointer Dereference Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Acrobat Reader Null Pointer Dereference Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Null Pointer Dereference Vulnerability. Acrobat Reader is prone to a null pointer dereference vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable null pointer dereference vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21057
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90377'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Out-Of-Bounds Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Out-Of-Bounds Read Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Acrobat Reader Out-Of-Bounds Read Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Out-Of-Bounds Read Vulnerability. Acrobat Reader is prone to an out-of-bounds read vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable out-of-bounds read vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21042
+- cve.2021.21034
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90376'
+    - '90372'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Out-of-Bounds Write Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Out-of-Bounds Write Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Acrobat Reader Out-of-Bounds Write Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Out-of-Bounds Write Vulnerability. Acrobat Reader is prone to an out-of-bounds write vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable out-of-bounds Write vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21038
+- cve.2021.21044
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90363'
+    - '90369'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Use-After-Free Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acrobat Reader Use-After-Free Vulnerability.yaml
@@ -1,0 +1,31 @@
+title: Acrobat Reader Use-After-Free Vulnerability
+description: Palo Alto Networks detection for Acrobat Reader Use-After-Free Vulnerability. Acrobat Reader is prone to a use-after-free vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable Use After Free vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21040
+- cve.2021.21039
+- cve.2021.21028
+- cve.2021.21021
+- cve.2021.21033
+- cve.2021.21061
+- cve.2021.21035
+- cve.2021.21041
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '90379'
+    - '90374'
+    - '90359'
+    - '90375'
+    - '90368'
+    - '90371'
+    - '90380'
+    - '90364'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acunetix Web Vulnerability Scanner Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Acunetix Web Vulnerability Scanner Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Acunetix Web Vulnerability Scanner Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for Acunetix Web Vulnerability Scanner Privilege Escalation Vulnerability. Acunetix Web Vulnerability Scanner is prone to a privilege escalation vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable privilege escalation vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2015.4027
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90930'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Acrobat Data Exfiltration Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Acrobat Data Exfiltration Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe Acrobat Data Exfiltration Vulnerability
+description: Palo Alto Networks detection for Adobe Acrobat Data Exfiltration Vulnerability. Adobe Acrobat is prone to a data exfiltration vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable data exfiltration vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2020.29075
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90116'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Application Server Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Application Server Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe ColdFusion Application Server Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Adobe ColdFusion Application Server Information Disclosure Vulnerability. Adobe Systems ColdFusion is prone to an information disclosure exists in Adobe ColdFusion. This vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure exists in Adobe ColdFusion. This vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2023.26361
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95053'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe ColdFusion Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Adobe ColdFusion convertToTemplateProxy Insecure Deserialization Vulnerability. Adobe Systems ColdFusion is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2023.26360
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95147'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Memory Corruption Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe ColdFusion Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Adobe ColdFusion Memory Corruption Vulnerability. Adobe ColdFusion is prone to a memory corruption vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could modify server-side variables that are not intended to be directly modifiable by the user.
+tags:
+- cve.2024.41874
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95576'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Remote File Inclusion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe ColdFusion Remote File Inclusion Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe ColdFusion Remote File Inclusion Vulnerability
+description: Palo Alto Networks detection for Adobe ColdFusion Remote File Inclusion Vulnerability. Adobe ColdFusion is prone to a remote file inclusion vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote file inclusion vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2024.34112
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95298'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Commerce XML External Entity Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Commerce XML External Entity Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe Commerce XML External Entity Vulnerability
+description: Palo Alto Networks detection for Adobe Commerce XML External Entity Vulnerability. Adobe Commerce is prone to a XML external entity vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XML external entity vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.34102
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95364'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Experience Manager Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Experience Manager Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Adobe Experience Manager Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Adobe Experience Manager Authentication Bypass Vulnerability. Adobe Experience Manager is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91325'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Magento Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Magento Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe Magento Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Adobe Magento Cross-Site Scripting Vulnerability. Adobe Systems Magento Commerce is prone to a reflected cross-site scripting vulnerability while parsing certain crafted responses. The vulnerability is due to the lack of proper checks on responses, leading to an exploitable reflected cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted response. A successful attack could lead to cross-site scripting.
+tags:
+- cve.2021.21029
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90861'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Arbitrary Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Arbitrary Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe Reader Arbitrary Code Execution Vulnerability
+description: Palo Alto Networks detection for Adobe Reader Arbitrary Code Execution Vulnerability. Adobe Reader is prone to an arbitrary code execution vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable arbitrary code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2021.21086
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91168'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Improper Input Validation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Improper Input Validation Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adobe Reader Improper Input Validation Vulnerability
+description: Palo Alto Networks detection for Adobe Reader Improper Input Validation Vulnerability. Adobe Reader is prone to a memory corruption vulnerability while parsing certain crafted JP2 files. The vulnerability is due to the lack of proper checks on JP2 files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted JP2 file. A successful attack could lead to memory corruption.
+tags:
+- cve.2021.21060
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90358'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adobe Reader Memory Corruption Vulnerability.yaml
@@ -1,0 +1,37 @@
+title: Adobe Reader Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Adobe Reader Memory Corruption Vulnerability. Adobe Reader is prone to a memory corruption vulnerability while parsing certain crafted PDF files. The vulnerability is due to the lack of proper checks on PDF files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted PDF file. A successful attack could lead to memory corruption.
+tags:
+- cve.2024.30311
+- cve.2021.21017
+- cve.2021.28550
+- cve.2021.28560
+- cve.2021.28554
+- cve.2021.28635
+- cve.2021.28640
+- cve.2021.28639
+- cve.2019.7110
+- cve.2021.39837
+- cve.2021.39840
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95221'
+    - '91783'
+    - '91205'
+    - '90849'
+    - '91359'
+    - '91360'
+    - '91424'
+    - '91105'
+    - '91782'
+    - '91714'
+    - '91106'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adtran Personal Phone Manager Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Adtran Personal Phone Manager Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Adtran Personal Phone Manager Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Adtran Personal Phone Manager Cross-Site Scripting Vulnerability. Adtran Personal Phone Manager is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.25680
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91092'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AdvanTech iView Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AdvanTech iView Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AdvanTech iView Directory Traversal Vulnerability
+description: Palo Alto Networks detection for AdvanTech iView Directory Traversal Vulnerability. AdvanTech iView is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.16245
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90220'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AdvanTech iView SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AdvanTech iView SQL Injection Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: AdvanTech iView SQL Injection Vulnerability
+description: Palo Alto Networks detection for AdvanTech iView SQL Injection Vulnerability. AdvanTech iView is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.22658
+- cve.2021.22654
+- cve.2022.2136
+- cve.2022.2135
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90779'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech EKI-6340 Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech EKI-6340 Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech EKI-6340 Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Advantech EKI-6340 Remote Command Execution Vulnerability. Advantech EKI-6340 is prone to a command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2014.8387
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90406'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech R-SeeNet XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech R-SeeNet XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech R-SeeNet XSS Vulnerability
+description: Palo Alto Networks detection for Advantech R-SeeNet Cross-Site Scripting Vulnerability. Advantech R-SeeNet is prone to a reflected cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable reflected cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to cross-site scripting.
+tags:
+- cve.2021.21799
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91732'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech R-SeeNet sshform.php XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech R-SeeNet sshform.php XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech R-SeeNet sshform.php XSS Vulnerability
+description: Palo Alto Networks detection for Advantech R-SeeNet sshform.php Cross-Site Scripting Vulnerability. Advantech R-SeeNet is prone to a reflected cross-site scripting vulnerability while parsing certain crafted responses. The vulnerability is due to the lack of proper checks on responses, leading to an exploitable reflected cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted response. A successful attack could lead to cross-site scripting.
+tags:
+- cve.2021.21800
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91624'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech iView Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech iView Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech iView Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Advantech iView Remote Code Execution Vulnerability. Advantech iView is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.22652
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90904'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech iView runProViewUpgrade Remote Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech iView runProViewUpgrade Remote Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech iView runProViewUpgrade Remote Command Injection Vulnerability
+description: Palo Alto Networks detection for Advantech iView runProViewUpgrade Remote Command Injection Vulnerability. Advantech iView is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.32930
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91242'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Introduces multiple Sigma detection rules for various vulnerabilities and exploits targeting third-party products, as detected in Palo Alto Networks PAN-OS firewall logs. These rules cover a wide range of CVEs and attack types, including code execution, buffer overflows, SQL injection, XSS, directory traversal, and privilege escalation, enhancing detection capabilities for security monitoring.