### PR TITLE
Add Palo Alto PAN-OS Sigma rules for various vulnerabilities

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AEM Hacker Toolset Traffic Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AEM Hacker Toolset Traffic Discovery.yaml
@@ -1,0 +1,15 @@
+title: AEM Hacker Toolset Traffic Discovery
+description: Palo Alto Networks detection for AEM Hacker Toolset Traffic Detection. This signature detects the traffic of AEM hacker toolset.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90948'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess Credential Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess Credential Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech WebAccess Credential Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Advantech WebAccess Credential Information Disclosure Vulnerability. Advantech WebAccess is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2016.5810
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90396'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess DBVisitor ChartThemeConfig SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess DBVisitor ChartThemeConfig SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Advantech WebAccess DBVisitor ChartThemeConfig SQL Injection Vulnerability
+description: Palo Alto Networks detection for Advantech WebAccess DBVisitor ChartThemeConfig SQL Injection Vulnerability. Advantech WebAccess is prone to an SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2014.0763
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90386'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess SCADA BwPAlarm Heap Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Advantech WebAccess SCADA BwPAlarm Heap Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Advantech WebAccess SCADA BwPAlarm Heap Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Advantech WebAccess SCADA BwPAlarm IOCTL 70022 Heap Buffer Overflow Vulnerability. Advantech WebAccess is prone to a heap buffer overflow vulnerability while parsing certain crafted RPC requests. The vulnerability is due to the lack of proper checks on RPC requests, leading to an exploitable heap buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted RPC requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90171'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Afterlogic Aurora Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Afterlogic Aurora Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Afterlogic Aurora Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for Afterlogic Aurora Arbitrary File Upload Vulnerability. Afterlogic Aurora is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.26293
+- cve.2021.26294
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90841'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Afterlogic Aurora Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Afterlogic Aurora Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Afterlogic Aurora Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Afterlogic Aurora Information Disclosure Vulnerability. Afterlogic Aurora is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2021.26292
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90840'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Agentejo Cockpit Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Agentejo Cockpit Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Agentejo Cockpit Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Agentejo Cockpit Authentication Bypass Vulnerability. Agentejo Cockpit is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.35847
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91026'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Agentejo Cockpit Username Enumeration Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Agentejo Cockpit Username Enumeration Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Agentejo Cockpit Username Enumeration Vulnerability
+description: Palo Alto Networks detection for Agentejo Cockpit Username Enumeration Vulnerability. Agentejo Cockpit is prone to a username enumeration vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable username enumeration vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.35846
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91027'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alcatel OmniPCX Office MasterCGI Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alcatel OmniPCX Office MasterCGI Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Alcatel OmniPCX Office MasterCGI Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Alcatel OmniPCX Office MasterCGI Remote Command Execution Vulnerability. Alcatel OmniPCX Office is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2007.3010
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '32721'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alibaba Nacos Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alibaba Nacos Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Alibaba Nacos Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Alibaba Nacos Authentication Bypass Vulnerability. Alibaba Nacos is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2021.29441
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91117'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alibaba Nacos Derby Improper Authorization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alibaba Nacos Derby Improper Authorization Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Alibaba Nacos Derby Improper Authorization Vulnerability
+description: Palo Alto Networks detection for Alibaba Nacos Derby Improper Authorization Vulnerability. Alibaba Nacos allows unauthorized requests to Derby database with certain endpoints, raising security concerns of SQL execution. This signature detects access to those endpoints without valid authorization.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95480'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra Excel Import Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra Excel Import Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Allegra Excel Import Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Allegra Excel Import Insecure Deserialization Vulnerability. Allegra is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2024.22506
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95106'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra GanttAndSchExportAction Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra GanttAndSchExportAction Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Allegra GanttAndSchExportAction Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Allegra GanttAndSchExportAction Directory Traversal Vulnerability. Allegra is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2023.22361
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95310'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra getFileContentAsString Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allegra getFileContentAsString Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Allegra getFileContentAsString Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Allegra getFileContentAsString Directory Traversal Vulnerability. Allegra is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.22530
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95105'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix 1400 Series B Ethernet Card Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix 1400 Series B Ethernet Card Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Allen Bradley Micrologix 1400 Series B Ethernet Card Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Allen Bradley Micrologix 1400 Series B Ethernet Card Denial-of-Service Vulnerability. Allen Bradley Micrologix 1400 Series is prone to a denial-of-service vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted TCP request. A successful attack could lead to denial-of-service.
+tags:
+- cve.2017.12088
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90199'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix 1400 Series B Ladder Logic DOS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix 1400 Series B Ladder Logic DOS Vulnerability.yaml
@@ -1,0 +1,28 @@
+title: Allen Bradley Micrologix 1400 Series B Ladder Logic DOS Vulnerability
+description: Palo Alto Networks detection for Allen Bradley Micrologix 1400 Series B Ladder Logic Denial-of-Service Vulnerability. Allen Bradley Micrologix 1400 Series is prone to a denial-of-service vulnerability while parsing certain crafted CIP requests. The vulnerability is due to the lack of proper checks on CIP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted CIP request. A successful attack could lead to denial-of-service.
+tags:
+- cve.2017.12089
+- cve.2017.14462
+- cve.2017.14463
+- cve.2017.14464
+- cve.2017.14465
+- cve.2017.14466
+- cve.2017.14467
+- cve.2017.14468
+- cve.2017.14469
+- cve.2017.14470
+- cve.2017.14471
+- cve.2017.14472
+- cve.2017.14473
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90198'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix Information Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Allen Bradley Micrologix Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Allen Bradley Micrologix Information Disclosure Vulnerability. Allen Bradley Micrologix is prone to an information disclosure vulnerability while parsing certain crafted CIP requests. The vulnerability is due to the lack of proper checks on CIP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted CIP request. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90215'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix SNMP-Set Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Allen Bradley Micrologix SNMP-Set Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Allen Bradley Micrologix SNMP-Set Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Allen Bradley Micrologix SNMP-Set Denial-of-Service Vulnerability. Allen Bradley Micrologix is prone to a denial-of-service vulnerability while parsing certain crafted SNMP requests. The vulnerability is due to the lack of proper checks on SNMP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted SNMP request. A successful attack could lead to denial-of-service.
+tags:
+- cve.2017.12090
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90193'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alliker Arbitrary File Upload Vunerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alliker Arbitrary File Upload Vunerability.yaml
@@ -1,0 +1,15 @@
+title: Alliker Arbitrary File Upload Vunerability
+description: Palo Alto Networks detection for Alliker Arbitrary File Upload Vunerability. Alliker is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95518'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alumni Management System SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Alumni Management System SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Alumni Management System SQL Injection Vulnerability
+description: Palo Alto Networks detection for Alumni Management System SQL Injection Vulnerability. Alumni Management System is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.28070
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90167'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ambarella Oryx RTSP Server Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ambarella Oryx RTSP Server Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Ambarella Oryx RTSP Server Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Ambarella Oryx RTSP Server Buffer Overflow Vulnerability. Ambarella Oryx is prone to a buffer overflow vulnerability while handling certain crafted RTSP requests. The vulnerability is due to the lack of proper checks on RTSP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted RTSP request. A successful exploit could allow remote code execution with the privileges of the server.
+tags:
+- cve.2020.24918
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91098'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Amino Communications Remote Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Amino Communications Remote Command Injection Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Amino Communications Remote Command Injection Vulnerability
+description: Palo Alto Networks detection for Amino Communications Remote Command Injection Vulnerability. Amino Communications is prone to a remote command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.10209
+- cve.2020.10208
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91023'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android ES File Explorer File Manager Policy Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android ES File Explorer File Manager Policy Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Android ES File Explorer File Manager Policy Bypass Vulnerability
+description: Palo Alto Networks detection for Android ES File Explorer File Manager Policy Bypass Vulnerability. Android ES File Explorer File Manager is prone to a policy bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable policy bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2019.6447
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95620'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android Libstagefright MP4 Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android Libstagefright MP4 Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,23 @@
+title: Android Libstagefright MP4 Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Android Libstagefright MP4 Buffer Overflow Vulnerability. Android libstagefright is prone to a buffer overflow vulnerability while parsing certain crafted MP4 files. The vulnerability is due to the lack of proper checks on MP4 files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted MP4 file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2015.3824
+- cve.2015.3864
+- cve.2015.3829
+- cve.2015.3827
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95622'
+    - '95625'
+    - '95623'
+    - '95624'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android Package Installer Elevation-of-Privileges Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android Package Installer Elevation-of-Privileges Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Android Package Installer Elevation-of-Privileges Vulnerability
+description: Palo Alto Networks detection for Android Package Installer Elevation-of-Privileges Vulnerability. Android package installer is prone to an elevation-of-privileges vulnerability while parsing certain crafted APK files. The vulnerability is due to the lack of proper checks on APK files, leading to an exploitable elevation-of-privileges vulnerability. An attacker could exploit the vulnerability by sending a crafted APK file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2017.13156
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95617'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android VFAT Filesystem Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android VFAT Filesystem Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Android VFAT Filesystem Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Android VFAT Filesystem Denial-of-Service Vulnerability. Android VFAT Filesystem implementation is prone to a buffer overflow vulnerability while parsing certain crafted APK files. The vulnerability is due to the lack of proper checks on APK files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted APK file. A successful attack could lead to denial-of-service with the privileges of the currently logged-in user.
+tags:
+- cve.2013.1773
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95611'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android libstagefright setSampleTopChunkParams Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Android libstagefright setSampleTopChunkParams Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Android libstagefright setSampleTopChunkParams Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Android libstagefright setSampleTopChunkParams Buffer Overflow Vulnerability. Android libstagefright is prone to a buffer overflow vulnerability while parsing certain crafted MP4 files. The vulnerability is due to the lack of proper checks on MP4 files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted MP4 file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2015.1538
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95644'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AndroxGh0st Scanning Traffic Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AndroxGh0st Scanning Traffic Discovery.yaml
@@ -1,0 +1,15 @@
+title: AndroxGh0st Scanning Traffic Discovery
+description: Palo Alto Networks detection for AndroxGh0st Scanning Traffic Detection. This signature detects the scanning traffic eminating from the AndroxGh0st malware.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '86759'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Expressions Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Expressions Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Angular Expressions Command Injection Vulnerability
+description: Palo Alto Networks detection for Angular Expressions Command Injection Vulnerability. Angular Expressions is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.54152
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95976'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Prototype Pollution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Prototype Pollution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Angular Prototype Pollution Vulnerability
+description: Palo Alto Networks detection for Angular Prototype Pollution Vulnerability. Angular is prone to a prototype pollution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable prototype pollution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2019.10768
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95944'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Regular Expression Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular Regular Expression Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Angular Regular Expression Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Angular Regular Expression Denial-of-Service Vulnerability. Angular is prone to a regular expression denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable regular expression denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to denial-of-service with the privileges of the server.
+tags:
+- cve.2023.26117
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95838'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular-Base64-Upload Library Unauthenticated RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Angular-Base64-Upload Library Unauthenticated RCE Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Angular-Base64-Upload Library Unauthenticated RCE Vulnerability
+description: Palo Alto Networks detection for Angular-Base64-Upload Library Unauthenticated Remote Code Execution Vulnerability. Angular-base64-upload is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.42640
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95690'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Anheng DAS-Gateway Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Anheng DAS-Gateway Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Anheng DAS-Gateway Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Anheng DAS-Gateway Remote Code Execution Vulnerability. Anheng DAS-Gateway is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '94469'
+    - '95352'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Anonymous Password Found in Inbound FTP Login Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Anonymous Password Found in Inbound FTP Login Attempt.yaml
@@ -1,0 +1,15 @@
+title: Anonymous Password Found in Inbound FTP Login Attempt
+description: Palo Alto Networks detection for Anonymous Password Found in Inbound FTP Login Attempt. An FTP login attempt with anonymous password was detected to a device. The use of an anonymous password may be a security risk.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90984'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AnyDesk Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AnyDesk Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AnyDesk Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for AnyDesk Remote Code Execution Vulnerability. AnyDesk is prone to a remote code execution vulnerability while parsing certain crafted UDP requests. The vulnerability is due to the lack of proper checks on UDP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted UDP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.13160
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58619'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache APISIX Dashboard Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache APISIX Dashboard Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache APISIX Dashboard Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache APISIX Dashboard Authentication Bypass Vulnerability. Apache APISIX Dashboard is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution and information disclosure.
+tags:
+- cve.2021.45232
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95980'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Artemis Jolokia Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Artemis Jolokia Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache ActiveMQ Artemis Jolokia Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for Apache ActiveMQ Artemis Jolokia Privilege Escalation Vulnerability. Apache ActiveMQ Artemis is prone to a privilege escalation vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable privilege escalation vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.50780
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '96009'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Apache ActiveMQ Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache ActiveMQ Remote Code Execution Vulnerability. Apache ActiveMQ is prone to a remote code execution vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.46604
+- cve.2020.11998
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95411'
+    - '90279'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Web Console QueueFilter XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Web Console QueueFilter XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache ActiveMQ Web Console QueueFilter XSS Vulnerability
+description: Palo Alto Networks detection for Apache ActiveMQ Web Console QueueFilter Cross-Site Scripting Vulnerability. Apache Software Foundation ActiveMQ is prone to a cross-site scripting vulnerability while parsing certain crafted responses. The vulnerability is due to the lack of proper checks on responses, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted response. A successful attack could lead to code execution.
+tags:
+- cve.2018.8006
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91945'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Web Console message.jsp Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache ActiveMQ Web Console message.jsp Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache ActiveMQ Web Console message.jsp Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Apache ActiveMQ Web Console message.jsp Cross-Site Scripting Vulnerability. Apache ActiveMQ is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.13947
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90401'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Airflow Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Airflow Command Injection Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Apache Airflow Command Injection Vulnerability
+description: Palo Alto Networks detection for Apache Airflow Command Injection Vulnerability. Apache Airflow is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.11978
+- cve.2020.13927
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91198'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Airflow Experimental API Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Airflow Experimental API Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Airflow Experimental API Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache Airflow Experimental API Authentication Bypass Vulnerability. Apache Airflow is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.13927
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95433'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache CloudStack SAML Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache CloudStack SAML Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache CloudStack SAML Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache CloudStack SAML Authentication Bypass Vulnerability. Apache Software Foundation CloudStack is prone to an authentication bypass injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to authentication bypass.
+tags:
+- cve.2024.41107
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95586'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache CouchDB Config Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache CouchDB Config Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache CouchDB Config Command Execution Vulnerability
+description: Palo Alto Networks detection for Apache CouchDB Config Command Execution Vulnerability. Apache Software Foundation CouchDB is prone to a command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2017.12636
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '54044'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Drill XML Format Plugin XML External Entity Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Drill XML Format Plugin XML External Entity Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Drill XML Format Plugin XML External Entity Injection Vulnerability
+description: Palo Alto Networks detection for Apache Drill XML Format Plugin XML External Entity Injection Vulnerability. Apache Software Foundation Drill is prone to an XXE vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XXE vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2023.48362
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95516'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Druid JDBC Connection Properties Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Druid JDBC Connection Properties Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Druid JDBC Connection Properties Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache Druid JDBC Connection Properties Remote Code Execution Vulnerability. Apache Software Foundation Druid is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.26919
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90966'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Dubbo Script Routing Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Dubbo Script Routing Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Dubbo Script Routing Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache Dubbo Script Routing Remote Code Execution Vulnerability. Apache Software Foundation Dubbo is prone to a remote code execution exists in the Script routing component of Apache Dubbo. The vulnerability while parsing certain crafted responses. The vulnerability is due to the lack of proper checks on responses, leading to an exploitable remote code execution exists in the Script routing component of Apache Dubbo. The vulnerability. An attacker could exploit the vulnerability by sending a crafted response. A successful attack could lead to code execution.
+tags:
+- cve.2021.30181
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91226'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Dubbo Unauthenticated Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Dubbo Unauthenticated Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Apache Dubbo Unauthenticated Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache Dubbo Unauthenticated Remote Code Execution Vulnerability. Apache Dubbo is prone to a remote code execution vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.25641
+- cve.2021.30179
+- cve.2023.23638
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91223'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Flink FileUploadHandler Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Flink FileUploadHandler Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Flink FileUploadHandler Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for Apache Flink FileUploadHandler Arbitrary File Upload Vulnerability. Apache Flink is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.17518
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95903'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Hertzbeat Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Hertzbeat Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Hertzbeat Deserialization Vulnerability
+description: Palo Alto Networks detection for Apache Hertzbeat Deserialization Vulnerability. Apache Hertzbeat is prone to a deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.42362
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95555'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma rule YAML files for Palo Alto Networks PAN-OS Firewall third-party log detections. These rules cover a wide range of vulnerabilities and threats, including information disclosure, remote code execution, SQL injection, buffer overflow, authentication bypass, and malware traffic detection for various products and CVEs.