### PR TITLE
3PL - Add Palo Alto Networks Sigma rules

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HTTP Server Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HTTP Server Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache HTTP Server Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Apache HTTP Server Information Disclosure Vulnerability. Apache HTTP Server is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.38475
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95533'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HTTPD ModCGI Handler Confusion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HTTPD ModCGI Handler Confusion Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache HTTPD ModCGI Handler Confusion Vulnerability
+description: Palo Alto Networks detection for Apache HTTPD ModCGI Handler Confusion Vulnerability. Apache Software Foundation HTTP Server is prone to a handler confusion vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable handler confusion vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2024.38476
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95649'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HttpComponents Man-in-the-Middle Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HttpComponents Man-in-the-Middle Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache HttpComponents Man-in-the-Middle Vulnerability
+description: Palo Alto Networks detection for Apache HttpComponents Man-in-the-Middle Vulnerability. Apache HttpComponents is prone to a man-in-the-middle vulnerability while parsing certain crafted SSL responses. The vulnerability is due to the lack of proper checks on SSL responses, leading to an exploitable man-in-the-middle vulnerability. An attacker could exploit the vulnerability by sending crafted SSL responses. A successful attack could lead to information disclosure.
+tags:
+- cve.2014.3577
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95445'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HugeGraph Server RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache HugeGraph Server RCE Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache HugeGraph Server RCE Vulnerability
+description: Palo Alto Networks detection for Apache HugeGraph Server Remote Code Execution Vulnerability. Apache HugeGraph Server is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.27348
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95315'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache JSPWiki UserPreferences.jsp Cross-Site Request Forgery Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache JSPWiki UserPreferences.jsp Cross-Site Request Forgery Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache JSPWiki UserPreferences.jsp Cross-Site Request Forgery Vulnerability
+description: Palo Alto Networks detection for Apache JSPWiki UserPreferences.jsp Cross-Site Request Forgery Vulnerability. Apache Software Foundation JSPWiki is prone to a cross-site request forgery vulnerability while parsing certain crafted responses. The vulnerability is due to the lack of proper checks on responses, leading to an exploitable cross-site request forgery vulnerability. An attacker could exploit the vulnerability by sending a crafted response. A successful attack could lead to policy bypass.
+tags:
+- cve.2022.28731
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95416'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Kafka Provectus UI JMX Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Kafka Provectus UI JMX Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Kafka Provectus UI JMX Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Apache Kafka Provectus UI JMX Insecure Deserialization Vulnerability. Apache Kafka Provectus UI is prone to an insecure deserialization vulnerability while parsing certain crafted RMI responses. The vulnerability is due to the lack of proper checks on RMI responses, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted RMI responses. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.32030
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95557'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Kylin Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Kylin Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Kylin Command Injection Vulnerability
+description: Palo Alto Networks detection for Apache Kylin Command Injection Vulnerability. Apache Kylin is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.1956
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58477'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Deserialization Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: Apache OFBiz Deserialization Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Deserialization Vulnerability. Apache OFBiz is prone to a deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.49070
+- cve.2021.26295
+- cve.2021.29200
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95140'
+    - '90900'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache OFBiz Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Directory Traversal Vulnerability. Apache OFBiz is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.36104
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95396'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache OFBiz Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Insecure Deserialization Vulnerability. Apache OFBiz is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.30128
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91097'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Path Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Path Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache OFBiz Path Traversal Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Path Traversal Vulnerability. Apache OFBiz is prone to a path traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable path traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.32113
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95274'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Server-Side Request Forgery Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz Server-Side Request Forgery Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Apache OFBiz Server-Side Request Forgery Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Server-Side Request Forgery Vulnerability. Apache OFBiz is prone to a server-side request forgery vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable server-side request forgery vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.45507
+- cve.2024.45195
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95655'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz loadJWT Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OFBiz loadJWT Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache OFBiz loadJWT Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz loadJWT Authentication Bypass Vulnerability. Apache Software Foundation OFBiz is prone to an authentication bypass vulnerability while parsing certain crafted HTTPS requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTPS request. A successful attack could lead to code execution.
+tags:
+- cve.2024.25065
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95316'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OfBiz Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OfBiz Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache OFBiz Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache OFBiz Remote Code Execution Vulnerability. Apache OFBiz is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.38856
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95471'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OpenMeetings Large Size Download Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OpenMeetings Large Size Download Attempt.yaml
@@ -1,0 +1,15 @@
+title: Apache OpenMeetings Large Size Download Attempt
+description: Palo Alto Networks detection for Apache OpenMeetings Large Size Download Attempt. This signature detects Apache OpenMeetings large size download attempt in HTTP requests. The signature is a child signature of the parent, Apache OpenMeetings Denial-of-Service Vulnerability(ID 40138). An individual trigger of this signature may not be malicious by itself. Normally, multiple triggers of this signature within a certain time period should be considered highly suspicious or malicious.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90908'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OpenMeetings Large Size Upload Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache OpenMeetings Large Size Upload Attempt.yaml
@@ -1,0 +1,15 @@
+title: Apache OpenMeetings Large Size Upload Attempt
+description: Palo Alto Networks detection for Apache OpenMeetings Large Size Upload Attempt. This signature detects Apache OpenMeetings large size upload attempt in HTTP requests. The signature is a child signature of the parent, Apache OpenMeetings Denial-of-Service Vulnerability(ID 40137). An individual trigger of this signature may not be malicious by itself. Normally, multiple triggers of this signature within a certain time period should be considered highly suspicious or malicious.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90906'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Pulsar JSON Web Token Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Pulsar JSON Web Token Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Apache Pulsar JSON Web Token Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache Pulsar JSON Web Token Authentication Bypass Vulnerability. Apache Pulsar is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2021.22160
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95858'
+    - '91217'
+    - '91215'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Seata Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Seata Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Seata Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Apache Seata Insecure Deserialization Vulnerability. Apache Seata is prone to an insecure deserialization vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to code execution.
+tags:
+- cve.2024.22399
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95846'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Shiro Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Shiro Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Shiro Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache Shiro Authentication Bypass Vulnerability. Apache Shiro is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.17523
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90354'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Arbitrary File Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Arbitrary File Read Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Apache Solr Arbitrary File Read Vulnerability
+description: Palo Alto Networks detection for Apache Solr Arbitrary File Read Vulnerability. Apache Solr is prone to an arbitrary file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90883'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Solr Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Apache Solr Authentication Bypass Vulnerability. Apache Solr is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.45216
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95794'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr File Upload Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Apache Solr File Upload Vulnerability
+description: Palo Alto Networks detection for Apache Solr File Upload Vulnerability. Apache Solr is prone to a file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.50386
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95072'
+    - '95647'
+    - '95643'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Solr Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Apache Solr Information Disclosure Vulnerability. Apache Solr is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2023.50290
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95073'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Server-Side Request Forgery Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Solr Server-Side Request Forgery Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Apache Solr Server-Side Request Forgery Vulnerability
+description: Palo Alto Networks detection for Apache Solr Server-Side Request Forgery Vulnerability. Apache Solr is prone to a server-side request forgery vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable server-side request forgery vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.27905
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '91667'
+    - '91052'
+    - '91479'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 Dynamic Method RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 Dynamic Method RCE Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Struts2 Dynamic Method RCE Vulnerability
+description: Palo Alto Networks detection for Apache Struts2 Dynamic Method Remote Code Execution Vulnerability. Apache Struts2 is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2013.4316
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '54739'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 File Upload Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 File Upload Bypass Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Apache Struts2 File Upload Bypass Vulnerability
+description: Palo Alto Networks detection for Apache Struts2 File Upload Bypass Vulnerability. Apache Struts is prone to a file upload bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable file upload bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to a file upload bypass.
+tags:
+- cve.2024.53677
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95862'
+    - '95861'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 OGNL Expression Handling Script Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 OGNL Expression Handling Script Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Struts2 OGNL Expression Handling Script Injection Vulnerability
+description: Palo Alto Networks detection for Apache Struts2 OGNL Expression Handling Script Injection Vulnerability. Apache Struts2 is prone to a script injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable script injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2012.0391
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '34933'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 OGNL Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Struts2 OGNL Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Apache Struts2 OGNL Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apache Struts2 OGNL Remote Code Execution Vulnerability. Apache Struts2 is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90336'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Superset Markdown Component Stored Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Superset Markdown Component Stored Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Superset Markdown Component Stored Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Apache Superset Markdown Component Stored Cross-Site Scripting Vulnerability. Apache Superset is prone to a stored cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stored cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.27907
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90998'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tapestry ClasspathAssetRequestHandler Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tapestry ClasspathAssetRequestHandler Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Tapestry ClasspathAssetRequestHandler Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Apache Tapestry ClasspathAssetRequestHandler Information Disclosure Vulnerability. Apache Tapestry is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2021.27850
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91051'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat FormAuthenticator Open Redirect Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat FormAuthenticator Open Redirect Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Tomcat FormAuthenticator Open Redirect Vulnerability
+description: Palo Alto Networks detection for Apache Tomcat FormAuthenticator Open Redirect Vulnerability. Apache Software Foundation Tomcat is prone to an open redirect vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable open redirect vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to policy bypass.
+tags:
+- cve.2023.41080
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95083'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat HTTP Request Smuggling Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat HTTP Request Smuggling Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Tomcat HTTP Request Smuggling Vulnerability
+description: Palo Alto Networks detection for Apache Tomcat HTTP Request Smuggling Vulnerability. Apache Tomcat is prone to a request smuggling vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable request smuggling vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.46589
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95067'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Tomcat Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Apache Tomcat Information Disclosure Vulnerability. Apache Tomcat is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.21733
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95063'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Servlet Engine Directory Traversal.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Servlet Engine Directory Traversal.yaml
@@ -1,0 +1,16 @@
+title: Apache Tomcat Servlet Engine Directory Traversal
+description: Palo Alto Networks detection for Apache Tomcat Servlet Engine Directory Traversal. There exists a directory traversal vulnerability in the Apache Tomcat. The vulnerability is due to an input validation error in Tomcat that does not properly sanitize the URI for the directory traversal patterns. Successful exploitation allows unauthenticated remote attackers to disclose or access arbitrary files on the vulnerable server.
+tags:
+- cve.2007.0450
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30873'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability.yaml
@@ -1,5 +1,5 @@
 title: Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability
-description: Palo Alto Networks detection for Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability. This signature is a child signature of the parent, Apache Tomcat Time-Of-Check Time-Of-Use Brute Force Attempt (ID 40165). An individual trigger of this make not be malicious itself. It is normally multiple triggers within a certain time period that should be considered highly suspicious or malicious.
+description: Palo Alto Networks detection for Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability. This signature is a child signature of the parent, Apache Tomcat Time-Of-Check Time-Of-Use Brute Force Attempt (ID 40165). An individual trigger of this may not be malicious itself. It is normally multiple triggers within a certain time period that should be considered highly suspicious or malicious.
 tags:
 - cve.2024.50379
 logsource:

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability
+description: Palo Alto Networks detection for Apache Tomcat Time-Of-Check Time-Of-Use Vulnerability. This signature is a child signature of the parent, Apache Tomcat Time-Of-Check Time-Of-Use Brute Force Attempt (ID 40165). An individual trigger of this make not be malicious itself. It is normally multiple triggers within a certain time period that should be considered highly suspicious or malicious.
+tags:
+- cve.2024.50379
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95868'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Traffic Server HTTP range Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Traffic Server HTTP range Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Traffic Server HTTP range Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Apache Traffic Server HTTP range Denial-of-Service Vulnerability. Apache Software Foundation Traffic Server is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to denial-of-service.
+tags:
+- cve.2023.39456
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95103'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Win32 Batch File Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache Win32 Batch File Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache Win32 Batch File Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Apache Win32 Batch File Remote Command Execution Vulnerability. Apache Win32 batch file is prone to a command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in the URI field in HTTP requests. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to execute commands at the privilege of the CGI program.
+tags:
+- cve.2002.0061
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30950'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache httpd modsed Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache httpd modsed Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache httpd modsed Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Apache httpd modsed Denial-of-Service Vulnerability. Apache Software Foundation HTTP Server is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to denial-of-service.
+tags:
+- cve.2022.30522
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95404'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache modperl Module XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apache modperl Module XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apache modperl Module XSS Vulnerability
+description: Palo Alto Networks detection for Apache modperl Module Cross-Site Scripting Vulnerability. Apache modperl Module is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2009.0796
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95932'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apollo Eureka Missing Authentication Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apollo Eureka Missing Authentication Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apollo Eureka Missing Authentication Vulnerability
+description: Palo Alto Networks detection for Apollo Eureka Missing Authentication Vulnerability. Apollo Eureka is prone to a missing authentication vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable missing authentication vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2023.25570
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95482'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CUPS Web Interface URL Handling XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CUPS Web Interface URL Handling XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple CUPS Web Interface URL Handling XSS Vulnerability
+description: Palo Alto Networks detection for Apple CUPS Web Interface URL Handling Cross-Site Scripting Vulnerability. Apple Computer Common UNIX Printing System (CUPS) is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to cross-site scripting.
+tags:
+- cve.2014.2856
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30350'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreGraphics Out-of-Bounds Write Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreGraphics Out-of-Bounds Write Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple CoreGraphics Out-of-Bounds Write Vulnerability
+description: Palo Alto Networks detection for Apple CoreGraphics Out-of-Bounds Write Vulnerability. Apple CoreGraphics is prone to an out-of-bounds write vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable out-of-bounds write vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2021.1776
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90961'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreText Integer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreText Integer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple CoreText Integer Overflow Vulnerability
+description: Palo Alto Networks detection for Apple CoreText Integer Overflow Vulnerability. Apple CoreText is prone to an integer overflow vulnerability while parsing certain crafted OTF files. The vulnerability is due to the lack of proper checks on OTF files, leading to an exploitable integer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted OTF file. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.27944
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90955'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreText Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple CoreText Memory Corruption Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Apple CoreText Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Apple CoreText Memory Corruption Vulnerability. Apple CoreText is prone to a memory corruption vulnerability while parsing certain crafted PFB files. The vulnerability is due to the lack of proper checks on PFB files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted PFB file. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.27943
+- cve.2020.29624
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90956'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Multiple Products Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Multiple Products Memory Corruption Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple Multiple Products Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Apple Multiple Products Memory Corruption Vulnerability. Apple Products are prone to a memory corruption vulnerability while parsing certain crafted PFB files. The vulnerability is due to the lack of proper checks on PFB files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted PFB file. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.27930
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90890'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Out-of-Bounds Write Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Out-of-Bounds Write Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple Out-of-Bounds Write Vulnerability
+description: Palo Alto Networks detection for Apple Out-of-Bounds Write Vulnerability. Apple is prone to an out-of-bounds write vulnerability while parsing certain crafted ATX files. The vulnerability is due to the lack of proper checks on ATX files, leading to an exploitable out-of-bounds write vulnerability. An attacker could exploit the vulnerability by sending a crafted ATX file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2020.29611
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90959'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Memory Corruption Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Apple Safari Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Apple Safari Memory Corruption Vulnerability. Apple Safari is prone to a memory corruption vulnerability while parsing certain crafted WASM files. The vulnerability is due to the lack of proper checks on WASM files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted WASM file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2021.30734
+- cve.2021.30797
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '91210'
+    - '91661'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Apple Safari Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Apple Safari Remote Code Execution Vulnerability. Apple Safari is prone to a remote code execution vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91181'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Use-After-Free Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple Safari Use-After-Free Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple Safari Use-After-Free Vulnerability
+description: Palo Alto Networks detection for Apple Safari Use-After-Free Vulnerability. Apple Safari is prone to a use-after-free vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable use-after-free vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to memory corruption condition with the privileges of the currently logged-in user.
+tags:
+- cve.2023.28205
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95795'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple WebKit iframe Sandbox Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Apple WebKit iframe Sandbox Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Apple WebKit iframe Sandbox Bypass Vulnerability
+description: Palo Alto Networks detection for Apple WebKit iframe Sandbox Bypass Vulnerability. Apple WebKit is prone to an iframe sandbox bypass vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable iframe sandbox bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to remote code execution.
+tags:
+- cve.2021.1801
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90419'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma rule YAML files for Palo Alto Networks PAN-OS Firewall third-party logs, targeting detection of various Apache-related vulnerabilities including information disclosure, RCE, authentication bypass, insecure deserialization, SSRF, and others. These rules enhance detection coverage for recent and historical CVEs affecting Apache products.