### PR TITLE
3PL - Add Sigma rules for PAN-OS firewall vulnerability detections

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AX86U Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AX86U Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ASUS RT-AX86U Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for ASUS RT-AX86U Buffer Overflow Vulnerability. ASUS RT-AX86U is prone to a buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.36109
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90400'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS_Netcore Router Default Credential Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS_Netcore Router Default Credential Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ASUS/Netcore Router Default Credential Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for ASUS/Netcore Router Default Credential Remote Code Execution Vulnerability. ASUS/Netcore is prone to a remote code execution vulnerability while parsing certain crafted requests. The vulnerability is due to the lack of proper checks in the UDP packet, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted UDP packet. A successful attack could lead to remote code execution with the privileges of the current logged-in user.
+tags:
+- cve.2014.9583
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '39438'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ATT U-verse Firmware Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ATT U-verse Firmware Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ATT U-verse Firmware Information Disclosure Vulnerability
+description: Palo Alto Networks detection for ATT U-verse Firmware Information Disclosure Vulnerability. ATT U-verse Firmware is prone to an information disclosure vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2017.14117
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90973'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ATX MiniCMTS200a Broadband Gateway Credential Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ATX MiniCMTS200a Broadband Gateway Credential Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ATX MiniCMTS200a Broadband Gateway Credential Disclosure Vulnerability
+description: Palo Alto Networks detection for ATX MiniCMTS200a Broadband Gateway Credential Disclosure Vulnerability. ATX MiniCMTS200a Broadband Gateway is prone to a credential disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable credential disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91114'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AVTECH IP Camera Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AVTECH IP Camera Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AVTECH IP Camera Command Injection Vulnerability
+description: Palo Alto Networks detection for AVTECH IP Camera Command Injection Vulnerability. AVTECH IP Camera is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.7029
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95645'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AWStats Totals Multisort Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AWStats Totals Multisort Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AWStats Totals Multisort Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for AWStats Totals Multisort Remote Command Execution Vulnerability. AWStats Totals is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2008.3922
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '55931'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AXIS Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AXIS Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AXIS Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for AXIS Remote Command Execution Vulnerability. AXIS is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2015.8257
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90982'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve D2D getNews External Entity Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve D2D getNews External Entity Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Arcserve D2D getNews External Entity Injection Vulnerability
+description: Palo Alto Networks detection for Arcserve D2D getNews External Entity Injection Vulnerability. Arcserve D2D is prone to an XXE vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XXE vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2020.27858
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90149'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve Unified Data Protection ASNative.dll Validate DOS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve Unified Data Protection ASNative.dll Validate DOS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Arcserve Unified Data Protection ASNative.dll Validate DOS Vulnerability
+description: Palo Alto Networks detection for Arcserve Unified Data Protection ASNative.dll Validate Denial-of-Service Vulnerability. Arcserve Unified Data Protection is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to denial-of-service with the privileges of the server.
+tags:
+- cve.2024.0801
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95613'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve Unified Data Protection doPost Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Arcserve Unified Data Protection doPost Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Arcserve Unified Data Protection doPost Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Arcserve Unified Data Protection ImportNodeServlet doPost Directory Traversal Vulnerability. Arcserve Unified Data Protection is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2024.0800
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95320'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy images.listener.php Arbitrary File Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy images.listener.php Arbitrary File Read Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Artica Proxy images.listener.php Arbitrary File Read Vulnerability
+description: Palo Alto Networks detection for Artica Proxy images.listener.php Arbitrary File Read Vulnerability. Artica Tech Artica Proxy is prone to an arbitrary file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.2053
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95582'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy squid.conf Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy squid.conf Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Artica Proxy squid.conf Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Artica Proxy squid.conf Authentication Bypass Vulnerability. Artica Tech Artica Proxy is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2024.2056
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95540'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy wiz.wizard.progress.php Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artica Proxy wiz.wizard.progress.php Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Artica Proxy wiz.wizard.progress.php Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for Artica Proxy wiz.wizard.progress.php Insecure Deserialization Vulnerability. Artica Tech Artica Proxy is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2024.2054
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95160'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artifex Ghostscript Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Artifex Ghostscript Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Artifex Ghostscript Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Artifex Ghostscript Remote Code Execution Vulnerability. Artifex Ghostscript is prone to a remote code execution vulnerability while parsing certain crafted EPS files. The vulnerability is due to the lack of proper checks on EPS files, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted EPS file. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.29510
+- cve.2019.14813
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95422'
+    - '90121'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Aruba Instant Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Aruba Instant Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Aruba Instant Code Execution Vulnerability
+description: Palo Alto Networks detection for Aruba Instant Code Execution Vulnerability. Aruba Instant is prone to a code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2016.2031
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95475'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Askey Internet Fiber Modem XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Askey Internet Fiber Modem XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Askey Internet Fiber Modem XSS Vulnerability
+description: Palo Alto Networks detection for Askey Internet Fiber Modem XSS Vulnerability. Askey Internet Fiber Modem is prone to a stored XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stored XSS vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2021.27403
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91020'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Aterm WG2600HP2 Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Aterm WG2600HP2 Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Aterm WG2600HP2 Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Aterm WG2600HP2 Information Disclosure Vulnerability. Aterm WG2600HP2 is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2017.12575
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90932'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Atlassian Jira Server Groupuserpicker Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Atlassian Jira Server Groupuserpicker Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Atlassian Jira Server Groupuserpicker Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Atlassian Jira Server and Data Center Groupuserpicker Information Disclosure Vulnerability. Atlassian JIRA is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2019.8449
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '93366'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Atlassian Jira Server and Data Center Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Atlassian Jira Server and Data Center Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Atlassian Jira Server and Data Center Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Atlassian Jira Server and Data Center Information Disclosure Vulnerability. Atlassian JIRA is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.26086
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '93630'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AudioCodes IP Phone 420HD Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/AudioCodes IP Phone 420HD Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: AudioCodes IP Phone 420HD Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for AudioCodes IP Phone 420HD Remote Command Execution Vulnerability. AudioCodes IP Phone is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.10093
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58176'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Avtech Devices Unauthenticated Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Avtech Devices Unauthenticated Information Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Avtech Devices Unauthenticated Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Avtech Devices Unauthenticated Information Disclosure Vulnerability. Avtech devices are prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on action field in the HTTP request, leading to an information disclosure. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30679'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Badaix Snapcast Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Badaix Snapcast Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Badaix Snapcast Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Badaix Snapcast Remote Code Execution Vulnerability. Badaix Snapcast is prone to a remote code execution vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.36177
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '96004'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Baolande BES Application Server Spark Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Baolande BES Application Server Spark Deserialization Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Baolande BES Application Server Spark Deserialization Vulnerability
+description: Palo Alto Networks detection for Baolande BES Application Server Spark Deserialization Vulnerability. BES Application Server is prone to a deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95840'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Basilic diff.php Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Basilic diff.php Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Basilic diff.php Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Basilic diff.php Remote Code Execution Vulnerability. Basilic 1.5.14 is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on metacharacters passed to diff.php script. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '35126'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bazaar Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bazaar Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Bazaar Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Bazaar Directory Traversal Vulnerability. Bazaar is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable path traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2024.40348
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95537'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beetel Router XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beetel Router XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Beetel Router XSS Vulnerability
+description: Palo Alto Networks detection for Beetel Router XSS Vulnerability. Beetel Router is prone to an XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.25498
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91046'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beijing Grandview Century eHR Software SQL Injection vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beijing Grandview Century eHR Software SQL Injection vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Beijing Grandview Century eHR Software SQL Injection vulnerability
+description: Palo Alto Networks detection for Beijing Grandview Century eHR Software SQL Injection vulnerability. Beijing Grandview Century eHR Software is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94052'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin Wemo UPnP API SmartDevURL OS Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin Wemo UPnP API SmartDevURL OS Command Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Belkin Wemo UPnP API SmartDevURL OS Command Injection Vulnerability
+description: Palo Alto Networks detection for Belkin Wemo UPnP API SmartDevURL OS Command Injection Vulnerability. Belkin Wemo UPnP is prone to a code injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90330'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beward IP Camera Remote File Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Beward IP Camera Remote File Read Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Beward IP Camera Remote File Read Vulnerability
+description: Palo Alto Networks detection for Beward IP Camera Remote File Read Vulnerability. Beward is prone to a file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable file read vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '55235'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BeyondTrust Multiple Products RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BeyondTrust Multiple Products RCE Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: BeyondTrust Multiple Products RCE Vulnerability
+description: Palo Alto Networks detection for BeyondTrust Multiple Products Remote Code Execution Vulnerability. BeyondTrust multiple products are prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.12356
+- cve.2025.1094
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '96016'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bitrix24 XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bitrix24 XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Bitrix24 XSS Vulnerability
+description: Palo Alto Networks detection for Bitrix24 Cross-Site Scripting Vulnerability. Bitrix24 is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.13483
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91033'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bootstrap Carousel XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Bootstrap Carousel XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Bootstrap Carousel XSS Vulnerability
+description: Palo Alto Networks detection for Bootstrap Carousel Cross-Site Scripting Vulnerability. Bootstrap carousel is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP responses. The vulnerability is due to the lack of proper checks on HTTP responses, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP responses. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2024.6484
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95797'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Broadwin WebAccess Client Bwocxrun ActiveX OcxSpool Format String Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Broadwin WebAccess Client Bwocxrun ActiveX OcxSpool Format String Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Broadwin WebAccess Client Bwocxrun ActiveX OcxSpool Format String Vulnerability
+description: Palo Alto Networks detection for Broadwin WebAccess Client Bwocxrun ActiveX OcxSpool Format String Vulnerability. Broadwin WebAccess Client Bwocxrun is prone to a format string vulnerability while parsing certain crafted HTML pages. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable format string vulnerability. An attacker could exploit the vulnerability by hosting a crafted HTML file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2012.0241
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90397'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BrowserUp Proxy Template Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/BrowserUp Proxy Template Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: BrowserUp Proxy Template Injection Vulnerability
+description: Palo Alto Networks detection for BrowserUp Proxy Template Injection Vulnerability. BrowserUp Proxy is prone to a template injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable content injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.26282
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90227'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CASAP Automated Enrollment System SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CASAP Automated Enrollment System SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CASAP Automated Enrollment System SQL Injection Vulnerability
+description: Palo Alto Networks detection for CASAP Automated Enrollment System SQL Injection Vulnerability. CASAP Automated Enrollment System is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.26201
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90805'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Arbitrary File Write Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Arbitrary File Write Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: Cacti Arbitrary File Write Vulnerability
+description: Palo Alto Networks detection for Cacti Arbitrary File Write Vulnerability. Cacti is prone to an arbitrary file write vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file write vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.25641
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95726'
+    - '95248'
+    - '95725'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Authenticated Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Authenticated Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cacti Authenticated Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Cacti Authenticated Remote Code Execution Vulnerability. Cacti is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2014.5261
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58715'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cacti Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cacti Command Injection Vulnerability
+description: Palo Alto Networks detection for Cacti Command Injection Vulnerability. Cacti is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.29895
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95239'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Canon PrintMe EFI Webinterface XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Canon PrintMe EFI Webinterface XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Canon PrintMe EFI Webinterface XSS Vulnerability
+description: Palo Alto Networks detection for Canon PrintMe EFI Webinterface XSS Vulnerability. Canon PrintMe EFI Webinterface is prone to a XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.12111
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90383'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Car Rental Management System File Inclusion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Car Rental Management System File Inclusion Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Car Rental Management System File Inclusion Vulnerability
+description: Palo Alto Networks detection for Car Rental Management System File Inclusion Vulnerability. Car Rental Management System is prone to a file inclusion vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable file inclusion vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.29227
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90136'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Centreon Web updateServiceHostMC SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Centreon Web updateServiceHostMC SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Centreon Web updateServiceHostMC SQL Injection Vulnerability
+description: Palo Alto Networks detection for Centreon Web updateServiceHostMC SQL Injection Vulnerability. Centreon Project Centreon Web is prone to an SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to SQL injection.
+tags:
+- cve.2024.32501
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95879'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ChangJieTong SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ChangJieTong SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ChangJieTong SQL Injection Vulnerability
+description: Palo Alto Networks detection for ChangJieTong SQL Injection Vulnerability. ChangJieTong is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95413'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Chanjet T Plus AppCode.ashx RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Chanjet T Plus AppCode.ashx RCE Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Chanjet T Plus AppCode.ashx RCE Vulnerability
+description: Palo Alto Networks detection for Chanjet T Plus AppCode.ashx RCE Vulnerability. Chanjet T Plus is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95338'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Check Point Security Gateway Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Check Point Security Gateway Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Check Point Security Gateway Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Check Point Security Gateway Directory Traversal Vulnerability. Check Point Security Gateway is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to code execution.
+tags:
+- cve.2024.24919
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95258'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance Software DOS Brute Force Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance Software DOS Brute Force Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Adaptive Security Appliance Software DOS Brute Force Vulnerability
+description: Palo Alto Networks detection for Cisco Adaptive Security Appliance Software Denial-of-Service Brute Force Vulnerability. Cisco Adaptive Security Appliance Software and Cisco Firepower Threat Defense Software are prone to a denial-of-service vulnerability while parsing certain crafted SIP requests. This signature triggers when the child signature, SIP Invalid Sent-by Address Found (ID 37299) triggers 50 times within 2 seconds. Customers can adjust the timing of brute force signatures if the parent signatures trigger too often. Refer to Palo Alto Networks documentation to learn more about brute force signatures and customizing the action and trigger conditions for a brute force signature.
+tags:
+- cve.2018.15454
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '40097'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Firepower Management Center Arbitrary File Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Firepower Management Center Arbitrary File Read Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Firepower Management Center Arbitrary File Read Vulnerability
+description: Palo Alto Networks detection for Cisco Firepower Management Center Arbitrary File Read Vulnerability. Cisco Firepower Management Center is prone to an arbitrary file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2016.6435
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91101'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco HyperFlex Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Cisco HyperFlex Directory Traversal Vulnerability. Cisco Hyperflex is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.1499
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91249'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex HX Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex HX Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco HyperFlex HX Command Injection Vulnerability
+description: Palo Alto Networks detection for Cisco HyperFlex HX Command Injection Vulnerability. Cisco HyperFlex HX is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.1497
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91203'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex HX Handling Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco HyperFlex HX Handling Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco HyperFlex HX Handling Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Cisco HyperFlex HX Handling Remote Command Execution Vulnerability. Cisco Systems HyperFlex Software is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2021.1498
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91158'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/axios Regular Expression Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/axios Regular Expression Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: axios Regular Expression Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for axios Regular Expression Denial-of-Service Vulnerability. axios is prone to a regular expression denial-of-service vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable regular expression denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to denial-of-service.
+tags:
+- cve.2021.3749
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95398'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma rule YAML files for Palo Alto Networks PAN-OS firewall third-party log detections. These rules cover a wide range of vulnerabilities including buffer overflow, remote code execution, information disclosure, command injection, authentication bypass, directory traversal, XSS, SQL injection, and more, targeting various network and security products. Each rule provides detection logic and context for identifying exploitation attempts in third-party logs.