### PR TITLE
Add Palo Alto PAN-OS Sigma rules for multiple CVEs

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CITSmart LDAP Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CITSmart LDAP Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CITSmart LDAP Injection Vulnerability
+description: Palo Alto Networks detection for CITSmart LDAP Injection Vulnerability. CITSmart is prone to an LDAP injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable LDAP injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.35775
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90983'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CMS Made Simple Server-Side Template Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CMS Made Simple Server-Side Template Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CMS Made Simple Server-Side Template Injection Vulnerability
+description: Palo Alto Networks detection for CMS Made Simple Server-Side Template Injection Vulnerability. CMS Made Simple is prone to a server-side template Injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable server-side template Injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.16783
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90856'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/COVID19 Testing Management System SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/COVID19 Testing Management System SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: COVID19 Testing Management System SQL Injection Vulnerability
+description: Palo Alto Networks detection for COVID19 Testing Management System SQL Injection Vulnerability. COVID19 Testing Management System is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.33470
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91225'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CTI Monitoring System Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CTI Monitoring System Information Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: CTI Monitoring System Information Disclosure Vulnerability
+description: Palo Alto Networks detection for CTI Monitoring System Information Disclosure Vulnerability. CTI Monitoring System is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP requests. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94621'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco ASA and FTD Arbitrary File Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco ASA and FTD Arbitrary File Read Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco ASA and FTD Arbitrary File Read Vulnerability
+description: Palo Alto Networks detection for Cisco ASA and FTD Arbitrary File Read Vulnerability. Cisco ASA and FTD are prone to an arbitrary file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2020.3452
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '59021'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance Web Services Denial of Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance Web Services Denial of Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Adaptive Security Appliance Web Services Denial of Service Vulnerability
+description: Palo Alto Networks detection for Cisco Adaptive Security Appliance Web Services Denial of Service Vulnerability. Cisco Adaptive Security Appliance (ASA) is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to a denial-of-service condition.
+tags:
+- cve.2018.0296
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '40797'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Adaptive Security Appliance XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Adaptive Security Appliance XSS Vulnerability
+description: Palo Alto Networks detection for Cisco Adaptive Security Appliance Cross-Site Scripting Vulnerability. Cisco Adaptive Security Appliance is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.3580
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91314'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Finesse Server-Side Request Forgery Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Finesse Server-Side Request Forgery Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Finesse Server-Side Request Forgery Vulnerability
+description: Palo Alto Networks detection for Cisco Finesse Server-Side Request Forgery Vulnerability. Cisco Finesse is prone to a server-side request forgery vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable server-side request forgery vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.20404
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95324'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOS HTTP Configuration Arbitrary Administrative Access Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOS HTTP Configuration Arbitrary Administrative Access Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco IOS HTTP Configuration Arbitrary Administrative Access Vulnerability
+description: Palo Alto Networks detection for Cisco IOS HTTP Configuration Arbitrary Administrative Access Vulnerability. Cisco IOS HTTP server is prone to a authentication bypass vulnerability while parsing certain crafted http request.The vulnerability is due to the lack of proper checks in URI field in the http reuquest.An attacker could exploit the vulnerability by sending a crafted http request. A successful attack could lead to execute any command on the device.
+tags:
+- cve.2001.0537
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30921'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOS XE Web UI Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOS XE Web UI Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco IOS XE Web UI Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Cisco IOS XE Web UI Authentication Bypass Vulnerability. Cisco IOS XE Web UI is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable broken access control vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.20198
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95146'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOx Application Environment Path Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco IOx Application Environment Path Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco IOx Application Environment Path Traversal Vulnerability
+description: Palo Alto Networks detection for Cisco IOx Application Environment Path Traversal Vulnerability. Cisco IOx Application Environment is prone to a path traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable path traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.1385
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95273'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Integrated Management Controller Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Integrated Management Controller Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Integrated Management Controller Command Injection Vulnerability
+description: Palo Alto Networks detection for Cisco Integrated Management Controller Command Injection Vulnerability. Cisco Integrated Management Controller is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.20356
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95194'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Jabber XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Jabber XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Jabber XSS Vulnerability
+description: Palo Alto Networks detection for Cisco Jabber Cross-Site Scripting Vulnerability. Cisco Jabber is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.26085
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90132'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV Series Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV Series Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco RV Series Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Cisco RV Series Remote Command Execution Vulnerability. Cisco RV Series is prone to a remote command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.1473
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91014'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV110W Router Stack Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV110W Router Stack Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco RV110W Router Stack Overflow Vulnerability
+description: Palo Alto Networks detection for Cisco RV110W Router Stack Overflow Vulnerability. Cisco RV110W Router is prone to a stack overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stack overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2021.1167
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90234'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV320_RV325 Router Unauthenticated Configuration Export Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV320_RV325 Router Unauthenticated Configuration Export Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability
+description: Palo Alto Networks detection for Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability. Cisco RV320/RV325 Router is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2019.1653
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '55025'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco SD-WAN vManage Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco SD-WAN vManage Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Cisco SD-WAN vManage Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Cisco SD-WAN vManage Remote Code Execution Vulnerability. Cisco SD-WAN vManage is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.3387
+- cve.2020.3437
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91207'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Small Business RV340 Series Routers Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Small Business RV340 Series Routers Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cisco Small Business RV340 Series Routers Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Cisco Small Business RV340 Series Routers Remote Command Execution Vulnerability. Cisco Small Business RV340 Series Router is prone to a remote command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.3451
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90924'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Gateway XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Gateway XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Citrix Gateway XSS Vulnerability
+description: Palo Alto Networks detection for Citrix Gateway Cross-Site Scripting Vulnerability. Citrix Gateway is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable cross-site scripting. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to reflect cross-site scripting.
+tags:
+- cve.2023.24488
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94329'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products Authorization Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products Authorization Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Citrix Multiple Products Authorization Bypass Vulnerability
+description: Palo Alto Networks detection for Citrix Multiple Products Authorization Bypass Vulnerability. Citrix ADC/Gateway/SDWAN WAN-OP are prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.8193
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58671'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products Code Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products Code Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Citrix Multiple Products Code Injection Vulnerability
+description: Palo Alto Networks detection for Citrix Multiple Products Code Injection Vulnerability. Citrix ADC/Gateway/SDWAN WAN-OP are prone to a code injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.8194
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58672'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Multiple Products XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Citrix Multiple Products XSS Vulnerability
+description: Palo Alto Networks detection for Citrix Multiple Products Cross-Site Scripting Vulnerability. Citrix ADC/Gateway/SDWAN WAN-OP are prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2020.8191
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '58669'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Session Recording Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Citrix Session Recording Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Citrix Session Recording Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Citrix Session Recording Remote Code Execution Vulnerability. Citrix Session Recording is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.8068
+- cve.2024.8069
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95786'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CivetWeb HTTP Server Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CivetWeb HTTP Server Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CivetWeb HTTP Server Directory Traversal Vulnerability
+description: Palo Alto Networks detection for CivetWeb HTTP Server Directory Traversal Vulnerability. CivetWeb is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2020.27304
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95995'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ClamAV initializeencryptionkey Out-Of-Bounds Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ClamAV initializeencryptionkey Out-Of-Bounds Read Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ClamAV initializeencryptionkey Out-Of-Bounds Read Vulnerability
+description: Palo Alto Networks detection for ClamAV initializeencryptionkey Out-Of-Bounds Read Vulnerability. ClamAV is prone to an out-of-bounds read vulnerability while parsing certain crafted OLE2 files. The vulnerability is due to the lack of proper checks on OLE2 files, leading to an exploitable out-of-bounds read vulnerability. An attacker could exploit the vulnerability by sending a crafted OLE2 file. A successful attack could lead to denial-of-service with the privileges of the server.
+tags:
+- cve.2024.20290
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95700'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cleo Harmony Arbitrary File Access Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cleo Harmony Arbitrary File Access Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cleo Harmony Arbitrary File Access Vulnerability
+description: Palo Alto Networks detection for Cleo Harmony Arbitrary File Access Vulnerability. Cleo Harmony is prone to an arbitrary file access vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file access vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.50623
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95834'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cleo Multiple Products Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cleo Multiple Products Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cleo Multiple Products Command Injection Vulnerability
+description: Palo Alto Networks detection for Cleo Multiple Products Command Injection Vulnerability. Cleo Multiple Products are prone to a command injection vulnerability while parsing certain crafted XML files. The vulnerability is due to the lack of proper checks on XML files, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted XML file. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.55956
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95896'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Climatix BACnetIP Communication Module XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Climatix BACnetIP Communication Module XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Climatix BACnetIP Communication Module XSS Vulnerability
+description: Palo Alto Networks detection for Climatix BACnetIP Communication Module Cross-Site Scripting Vulnerability. Climatix BACnet/IP communication module is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2015.4174
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95908'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cobalt Strike Command and Control Traffic Alert.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cobalt Strike Command and Control Traffic Alert.yaml
@@ -1,0 +1,19 @@
+title: Cobalt Strike Command and Control Traffic Alert
+description: Palo Alto Networks detection for Cobalt Strike Command and Control Traffic Detection. This signature detects CobaltStrike.Gen Malicious Payload.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '11001'
+    - '11018'
+    - '12067'
+    - '13012'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cobbler Improper Authentication Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cobbler Improper Authentication Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cobbler Improper Authentication Vulnerability
+description: Palo Alto Networks detection for Cobbler Improper Authentication Vulnerability. Cobbler is prone to an improper authentication vulnerability while parsing certain crafted XMLRPC requests. The vulnerability is due to the lack of proper checks on XMLRPC requests, leading to an exploitable improper authentication vulnerability. An attacker could exploit the vulnerability by sending crafted XMLRPC requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.47533
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95793'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cockpit Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cockpit Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Cockpit Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Cockpit Remote Command Execution Vulnerability. Cockpit is prone to a remote command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.35131
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90388'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CodeSYS Heap Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CodeSYS Heap Overflow Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: CodeSYS Heap Overflow Vulnerability
+description: Palo Alto Networks detection for CodeSYS Heap Overflow Vulnerability. CodeSYS is prone to a heap overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable heap overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90293'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Complaint Management System SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Complaint Management System SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Complaint Management System SQL Injection Vulnerability
+description: Palo Alto Networks detection for Complaint Management System SQL Injection Vulnerability. Complaint Management System is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90273'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Composer Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Composer Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Composer Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Composer Remote Code Execution Vulnerability. Composer is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.29472
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91075'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Composr Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Composr Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Composr Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for Composr Arbitrary File Upload Vulnerability. Composr is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.30149
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90960'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Compromised ConnectWise ScreenConnect Post-Exploitation Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Compromised ConnectWise ScreenConnect Post-Exploitation Discovery.yaml
@@ -1,0 +1,16 @@
+title: Compromised ConnectWise ScreenConnect Post-Exploitation Discovery
+description: Palo Alto Networks detection for Compromised ConnectWise ScreenConnect Post-Exploitation Detection. This signature detects remote code execution traffic targeting compromised ConnectWise ScreenConnect
+tags:
+- cve.2024.1708
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95064'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Confluence Data Center and Server Improper Authorization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Confluence Data Center and Server Improper Authorization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Confluence Data Center and Server Improper Authorization Vulnerability
+description: Palo Alto Networks detection for Confluence Data Center and Server Improper Authorization Vulnerability. Confluence Data Center and Server is prone to an improper authorization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable improper authorization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.22518
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95151'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Confluence Data Center and Server RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Confluence Data Center and Server RCE Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Confluence Data Center and Server RCE Vulnerability
+description: Palo Alto Networks detection for Confluence Data Center and Server Remote Code Execution Vulnerability. Confluence Data Center and Server is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.21683
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95249'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ConnectWise ScreenConnect Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ConnectWise ScreenConnect Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ConnectWise ScreenConnect Directory Traversal Vulnerability
+description: Palo Alto Networks detection for ConnectWise ScreenConnect Directory Traversal Vulnerability. ConnectWise ScreenConnect is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2024.1708
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95069'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Corel PDF Fusion XPS Stack Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Corel PDF Fusion XPS Stack Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Corel PDF Fusion XPS Stack Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Corel PDF Fusion XPS Stack Buffer Overflow Vulnerability. Corel PDF Fusion is prone to a stack buffer overflow vulnerability while parsing certain crafted XPS files. The vulnerability is due to the lack of proper checks on XPS files, leading to an exploitable stack buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted XPS file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2013.3248
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95930'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Coremail Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Coremail Information Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Coremail Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Coremail Information Disclosure Vulnerability. Coremail is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91331'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CourseMS Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CourseMS Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CourseMS Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for CourseMS Cross-Site Scripting Vulnerability. CoursMS is prone to a cross-site scripting vulnerability vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2021.29663
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90939'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CrushFTP Arbitrary File Read Vulneraability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CrushFTP Arbitrary File Read Vulneraability.yaml
@@ -1,0 +1,16 @@
+title: CrushFTP Arbitrary File Read Vulneraability
+description: Palo Alto Networks detection for CrushFTP Arbitrary File Read Vulneraability. CrushFTP is prone to an arbitrary file read vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2024.4040
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95201'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Curl Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Curl Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Curl Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Curl Denial-of-Service Vulnerability. curl is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to denial-of-service.
+tags:
+- cve.2022.35252
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95603'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Curl Set-Cookie Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Curl Set-Cookie Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Curl Set-Cookie Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Curl Set-Cookie Denial-of-Service Vulnerability. Curl is prone to a denial-of-service vulnerability while parsing certain crafted HTTP responses. The vulnerability is due to the lack of proper checks on HTTP responses, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP responses. A successful attack could lead to denial-of-service with the privileges of the currently logged-in user.
+tags:
+- cve.2022.32205
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95814'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CutePHP CuteNews Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/CutePHP CuteNews Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: CutePHP CuteNews Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for CutePHP CuteNews Remote Code Execution Vulnerability. CutePHP CuteNews is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2019.11447
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90326'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cPanel ErrorPage XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cPanel ErrorPage XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: cPanel ErrorPage XSS Vulnerability
+description: Palo Alto Networks detection for cPanel ErrorPage Cross-Site Scripting Vulnerability. cPanel ErrorPage is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.29489
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94845'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cURL HSTS Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cURL HSTS Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: cURL HSTS Bypass Vulnerability
+description: Palo Alto Networks detection for cURL HSTS Bypass Vulnerability. cURL is prone to a HSTS bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable HSTS bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2022.43551
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '93553'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cURL Transfer-Encoding Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/cURL Transfer-Encoding Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: cURL Transfer-Encoding Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for cURL Transfer-Encoding Denial-of-Service Vulnerability. cURL is prone to a denial-of-service vulnerability while parsing certain crafted HTTP responses. The vulnerability is due to the lack of proper checks on HTTP responses, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP responses. A successful attack could lead to denial-of-service with the privileges of the currently logged-in user.
+tags:
+- cve.2022.32206
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95818'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/curl Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/curl Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: curl Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for curl Buffer Overflow Vulnerability. curl is prone to a buffer overflow vulnerability while parsing certain crafted Telnet requests. The vulnerability is due to the lack of proper checks on Telnet requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted Telnet requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2021.22898
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95406'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added new Sigma detection rules for various vulnerabilities and exploits affecting third-party products in Palo Alto Networks PAN-OS Firewall logs. These include LDAP injection, SQL injection, XSS, RCE, command injection, authentication bypass, and other critical vulnerabilities, each mapped to specific CVEs and detection rule IDs.