### PR TITLE
Add Palo Alto Networks Sigma rules for Z-related vulnerabilities

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YONYOU GRP-U8 Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YONYOU GRP-U8 Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: YONYOU GRP-U8 Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for YONYOU GRP-U8 Arbitrary File Upload Vulnerability. YONYOU GRP-U8 is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95326'
+    - '95337'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YONYOU Mobile System Management Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YONYOU Mobile System Management Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: YONYOU Mobile System Management Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for YONYOU Mobile System Management Arbitrary File Upload Vulnerability. YONYOU Mobile System Management is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95333'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YongYou U8 UFIDA CRM Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YongYou U8 UFIDA CRM Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: YongYou U8 UFIDA CRM Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for YongYou U8 UFIDA CRM Arbitrary File Upload Vulnerability. YongYou is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file read vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95334'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Yongyou U8 cloud MonitorServlet Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Yongyou U8 cloud MonitorServlet Deserialization Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Yongyou U8 cloud MonitorServlet Deserialization Vulnerability
+description: Palo Alto Networks detection for Yongyou U8 cloud MonitorServlet Deserialization Vulnerability. Yongyou U8 cloud is prone to a deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable deserialization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95449'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Yonyou NC-Cloud Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Yonyou NC-Cloud Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Yonyou NC-Cloud Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for Yonyou NC-Cloud Arbitrary File Upload Vulnerability. Yonyou NC-Cloud is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94305'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YzmCMS paycallback RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/YzmCMS paycallback RCE Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: YzmCMS paycallback RCE Vulnerability
+description: Palo Alto Networks detection for YzmCMS paycallback RCE Vulnerability. YzmCMS is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95335'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZEROF Expert SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZEROF Expert SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ZEROF Expert SQL Injection Vulnerability
+description: Palo Alto Networks detection for ZEROF Expert SQL Injection Vulnerability. ZEROF Expert is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.30176
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90976'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZEROF Web Server SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZEROF Web Server SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: ZEROF Web Server SQL Injection Vulnerability
+description: Palo Alto Networks detection for ZEROF Web Server SQL Injection Vulnerability. ZEROF Web Server is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.30175
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90975'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZGrab Application Layer Scanner Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZGrab Application Layer Scanner Discovery.yaml
@@ -1,0 +1,15 @@
+title: ZGrab Application Layer Scanner Discovery
+description: Palo Alto Networks detection for ZGrab Application Layer Scanner Detection. This signature indicates that an attacker is trying to collect information about the network by using the ZGrab Scanner.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '57955'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Audit Log SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Audit Log SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zabbix Audit Log SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zabbix Audit Log SQL Injection Vulnerability. Zabbix is prone to a SQL injection vulnerability while parsing certain crafted Zabbix Trapper requests. The vulnerability is due to the lack of proper checks on Zabbix Trapper requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted Zabbix Trapper requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2024.22120
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95583'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Geomap Stored Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Geomap Stored Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zabbix Geomap Stored Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Zabbix Geomap Stored Cross-Site Scripting Vulnerability. ZABBIX is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to cross-site scripting.
+tags:
+- cve.2023.29452
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95050'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Ping Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zabbix Ping Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zabbix Ping Command Injection Vulnerability
+description: Palo Alto Networks detection for Zabbix Ping Command Injection Vulnerability. Zabbix is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.22116
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95598'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zen Cart Code Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zen Cart Code Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zen Cart Code Injection Vulnerability
+description: Palo Alto Networks detection for Zen Cart Code Injection Vulnerability. Zen Cart is prone to a code injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91086'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ZenTao Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for ZenTao Authentication Bypass Vulnerability. ZenTao is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95454'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao Backstage Comand Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao Backstage Comand Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ZenTao Backstage Comand Injection Vulnerability
+description: Palo Alto Networks detection for ZenTao Backstage Comand Injection Vulnerability. ZenDao Backstage is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95124'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao PMS Improper Authorization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZenTao PMS Improper Authorization Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ZenTao PMS Improper Authorization Vulnerability
+description: Palo Alto Networks detection for ZenTao PMS Improper Authorization Vulnerability. ZenTao PMS is prone to an improper authorization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable improper authorization vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91326'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zenario CMS SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zenario CMS SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zenario CMS SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zenario CMS SQL Injection Vulnerability. Zenario CMS is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.26830
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91058'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zend Framework Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zend Framework Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zend Framework Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Zend Framework Remote Code Execution Vulnerability. Zend Framework is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.3007
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90278'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zephyr OS Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zephyr OS Memory Corruption Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Zephyr OS Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Zephyr OS Memory Corruption Vulnerability. Zephyr OS is prone to a memory corruption vulnerability while parsing certain crafted MQTT requests. The vulnerability is due to the lack of proper checks on MQTT requests, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending crafted MQTT requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.10062
+- cve.2020.10070
+- cve.2020.10071
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91252'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZhiYuan OA M1Server userTokenService RCE Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZhiYuan OA M1Server userTokenService RCE Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ZhiYuan OA M1Server userTokenService RCE Vulnerability
+description: Palo Alto Networks detection for ZhiYuan OA M1Server userTokenService Remote Code Execution Vulnerability. ZhiYuan OA M1Server is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95327'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Command Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zhiyuan OA Command Injection Vulnerability
+description: Palo Alto Networks detection for Zhiyuan OA Command Injection Vulnerability. Zhiyuan OA is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95637'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Information Disclosure Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zhiyuan OA Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Zhiyuan OA Information Disclosure Vulnerability. Zhiyuan OA is prone to an information vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91244'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhiyuan OA Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zhiyuan OA Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Zhiyuan OA Remote Code Execution Vulnerability. Zhiyuan OA is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '59461'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhongyuan Qilin SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zhongyuan Qilin SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zhongyuan Qilin SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zhongyuan Qilin SQL Injection Vulnerability. Zhongyuan Qilin is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94663'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zimbra Collaboration Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zimbra Collaboration Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zimbra Collaboration Command Execution Vulnerability
+description: Palo Alto Networks detection for Zimbra Collaboration Command Execution Vulnerability. Zimbra Collaboration is prone to a command execution vulnerability while parsing certain crafted SMTP requests. The vulnerability is due to the lack of proper checks on SMTP requests, leading to an exploitable command execution vulnerability. An attacker could exploit the vulnerability by sending crafted SMTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2024.45519
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95667'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zimbra Collaboration Server Local File Include Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zimbra Collaboration Server Local File Include Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zimbra Collaboration Server Local File Include Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for Zimbra Collaboration Server Local File Include Privilege Escalation Vulnerability. Zimbra 7.2.2 and 8.0.2 are prone to a local file include vulnerability while parsing certain crafted HTTP requests. The vulnerability is present in certain template files, which allow directory traversal paths. An attacker could exploit the vulnerability by sending a crafted skin parameter in a HTTP request. The attacker could retrieve ldap credentials through the directory traversal attempt. The credentials could then be used to create users, directories, upload and execute arbitrary code.
+tags:
+- cve.2013.7091
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '36355'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zlib Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zlib Memory Corruption Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zlib Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Zlib Memory Corruption Vulnerability. Zlib is prone to a memory corruption vulnerability while parsing certain crafted TXT files. The vulnerability is due to the lack of proper checks on TXT files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted TXT file. A successful attack could lead to remote code execution.
+tags:
+- cve.2018.25032
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95478'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine ADAudit Plus getLockoutHistoryData SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine ADAudit Plus getLockoutHistoryData SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zoho ManageEngine ADAudit Plus getLockoutHistoryData SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zoho ManageEngine ADAudit Plus getLockoutHistoryData SQL Injection Vulnerability. Zoho Corporation ManageEngine ADAudit Plus is prone to an SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to SQL injection.
+tags:
+- cve.2024.5467
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95660'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine ADManager Plus Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine ADManager Plus Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zoho ManageEngine ADManager Plus Command Injection Vulnerability
+description: Palo Alto Networks detection for Zoho ManageEngine ADManager Plus Command Injection Vulnerability. Zoho ManageEngine ADManager Plus is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.29084
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '93720'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Applications Manager SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Applications Manager SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Zoho ManageEngine Applications Manager SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zoho ManageEngine Applications Manager showMonitorGroupView SQL Injection Vulnerability. Zoho Corporation ManageEngine Applications Manager is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90158'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Applications Manager UriCollector SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Applications Manager UriCollector SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zoho ManageEngine Applications Manager UriCollector SQL Injection Vulnerability
+description: Palo Alto Networks detection for Zoho ManageEngine Applications Manager UriCollector SQL Injection Vulnerability. Zoho ManageEngine Applications Manager is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.35765
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90554'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Desktop Central Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zoho ManageEngine Desktop Central Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zoho ManageEngine Desktop Central Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Zoho ManageEngine Desktop Central Authentication Bypass Vulnerability. Zoho ManageEngine Desktop Central is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2021.44515
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95311'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZyWall USG Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZyWall USG Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: ZyWall USG Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for ZyWall USG Arbitrary File Upload Vulnerability. ZyWall USG is prone to an arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90185'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel Multiple Products Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel Multiple Products Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zyxel Multiple Products Command Injection Vulnerability
+description: Palo Alto Networks detection for Zyxel Multiple Products Command Injection Vulnerability. Zyxel multiple products are prone to a command injection vulnerability while parsing certain crafted IKE requests. The vulnerability is due to the lack of proper checks on IKE requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted IKE requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2023.28771
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95141'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel NBG2105 Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel NBG2105 Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zyxel NBG2105 Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for Zyxel NBG2105 Privilege Escalation Vulnerability. Zyxel NBG2105 is prone to a privilege escalation vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable privilege escalation vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.3297
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90988'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel USG Backdoor Account Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Zyxel USG Backdoor Account Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Zyxel USG Backdoor Account Vulnerability
+description: Palo Alto Networks detection for Zyxel USG Backdoor Account Vulnerability. Zyxel USG is prone to a hardcoded backdoor vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable hardcoded backdoor account. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.29583
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90183'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma detection rules for Palo Alto Networks PAN-OS Firewall logs, covering a range of vulnerabilities in products starting with 'Y' and 'Z', including arbitrary file upload, SQL injection, command injection, remote code execution, authentication bypass, and information disclosure. These rules enhance detection for recent and historical CVEs across various third-party applications.