### PR TITLE
PAN - New CDF

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NETGEAR SOAP Authentication Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NETGEAR SOAP Authentication Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NETGEAR SOAP Authentication Command Injection Vulnerability
+description: Palo Alto Networks detection for NETGEAR WNR2000v4 SOAP Authentication Command Injection Vulnerability. NETGEAR WNR2000v4 is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.50089
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95971'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NI FlexLogger FLXPROJ File Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NI FlexLogger FLXPROJ File Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NI FlexLogger FLXPROJ File Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for NI FlexLogger FLXPROJ File ParseDataValueAsXmlHierarchy Insecure Deserialization Vulnerability. National Instruments FlexLogger is prone to an insecure deserialization vulnerability while parsing certain crafted FLXPROJ files. The vulnerability is due to the lack of proper checks on FLXPROJ files, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending a crafted FLXPROJ file. A successful attack could lead to code execution.
+tags:
+- cve.2024.4044
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95988'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NPM IP Package Server-Side Request Forgery Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NPM IP Package Server-Side Request Forgery Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NPM IP Package Server-Side Request Forgery Vulnerability
+description: Palo Alto Networks detection for NPM IP Package Server-Side Request Forgery Vulnerability. NPM IP package is prone to a server-side request forgery vulnerability while parsing certain crafted JavaScript files. The vulnerability is due to the lack of proper checks on JavaScript files, leading to an exploitable server-side request forgery vulnerability. An attacker could exploit the vulnerability by sending a crafted JavaScript file. A successful attack could lead to information disclosure.
+tags:
+- cve.2023.42282
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95070'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NSFocus ADS Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NSFocus ADS Command Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: NSFocus ADS Command Injection Vulnerability
+description: Palo Alto Networks detection for NSFocus ADS Command Injection Vulnerability. NSFocus ADS is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95520'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NTP Reserved Mode Denial of Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NTP Reserved Mode Denial of Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NTP Reserved Mode Denial of Service Vulnerability
+description: Palo Alto Networks detection for NTP Reserved Mode Denial of Service Vulnerability. NTP is prone to a DoS vulnerability while parsing certain crafted NTP requests.The vulnerability is due to the lack of proper checks in the NTP request, leading to an exploitable DoS. An attacker could exploit the vulnerability by sending a crafted NTP request. A successful attack could lead to remote DoS with the privileges of the server.
+tags:
+- cve.2009.3563
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '33273'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Heap Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Heap Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NVIDIA CUDA Toolkit cuobjdump Heap Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for NVIDIA CUDA Toolkit cuobjdump Heap Buffer Overflow Vulnerability. NVIDIA CUDA Toolkit cuobjdump is prone to a heap buffer overflow vulnerability while parsing certain crafted ELF files. The vulnerability is due to the lack of proper checks on ELF files, leading to an exploitable heap buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted ELF file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2024.53872
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95849'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Integer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Integer Overflow Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: NVIDIA CUDA Toolkit cuobjdump Integer Overflow Vulnerability
+description: Palo Alto Networks detection for NVIDIA CUDA Toolkit cuobjdump Integer Overflow Vulnerability. NVIDIA CUDA Toolkit cuobjdump is prone to an integer overflow vulnerability while parsing certain crafted ELF files. The vulnerability is due to the lack of proper checks on ELF files, leading to an exploitable integer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted ELF file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2024.53873
+- cve.2024.53870
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95847'
+    - '95852'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Out-of-Bounds Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit cuobjdump Out-of-Bounds Read Vulnerability.yaml
@@ -1,0 +1,21 @@
+title: NVIDIA CUDA Toolkit cuobjdump Out-of-Bounds Read Vulnerability
+description: Palo Alto Networks detection for NVIDIA CUDA Toolkit cuobjdump Out-of-Bounds Read Vulnerability. NVIDIA CUDA Toolkit cuobjdump is prone to an out-of-bounds read vulnerability while parsing certain crafted ELF files. The vulnerability is due to the lack of proper checks on ELF files, leading to an exploitable out-of-bounds read vulnerability. An attacker could exploit the vulnerability by sending a crafted ELF file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2024.53874
+- cve.2024.53878
+- cve.2024.53875
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95850'
+    - '95856'
+    - '95848'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit nvdisasm Heap Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit nvdisasm Heap Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NVIDIA CUDA Toolkit nvdisasm Heap Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for NVIDIA CUDA Toolkit nvdisasm Heap Buffer Overflow Vulnerability. NVIDIA CUDA Toolkit nvdisasm is prone to a heap buffer overflow vulnerability while parsing certain crafted ELF files. The vulnerability is due to the lack of proper checks on ELF files, leading to an exploitable heap buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted ELF file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2024.53877
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95854'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit nvdisasm Out-of-Bounds Read Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NVIDIA CUDA Toolkit nvdisasm Out-of-Bounds Read Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: NVIDIA CUDA Toolkit nvdisasm Out-of-Bounds Read Vulnerability
+description: Palo Alto Networks detection for NVIDIA CUDA Toolkit nvdisasm Out-of-Bounds Read Vulnerability. NVIDIA CUDA Toolkit nvdisasm is prone to an out-of-bounds read vulnerability while parsing certain crafted ELF files. The vulnerability is due to the lack of proper checks on ELF files, leading to an exploitable out-of-bounds read vulnerability. An attacker could exploit the vulnerability by sending a crafted ELF file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2024.53871
+- cve.2024.53876
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95855'
+    - '95853'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 ReportTemplateController Arbitrary File Deletion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 ReportTemplateController Arbitrary File Deletion Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE NMS300 ReportTemplateController Arbitrary File Deletion Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE NMS300 ReportTemplateController Arbitrary File Deletion Vulnerability. Netgear ProSAFE NMS300 is prone to an arbitrary file deletion vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file deletion vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to denial of service.
+tags:
+- cve.2021.27272
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90970'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 SQL Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE NMS300 SQL Injection Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE NMS300 SQL Injection Vulnerability. Netgear ProSAFE NMS300 is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to SQL injection.
+tags:
+- cve.2023.44449
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95293'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 UpLoadServlet Unrestricted File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE NMS300 UpLoadServlet Unrestricted File Upload Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE NMS300 UpLoadServlet Unrestricted File Upload Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE NMS300 UpLoadServlet Unrestricted File Upload Vulnerability. Netgear ProSAFE NMS300 is prone to an unrestricted file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable unrestricted file upload vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2023.38098
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95082'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE Plus Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE Plus Buffer Overflow Vulnerability. Netgear ProSAFE Plus is prone to a buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.35227
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90826'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE Plus Command Execution Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE Plus Command Execution Vulnerability. Netgear ProSAFE Plus is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote command execution with the privileges of the server.
+tags:
+- cve.2020.35223
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90828'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Integer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Integer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE Plus Integer Overflow Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE Plus Integer Overflow Vulnerability. Netgear ProSAFE Plus is prone to an integer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable integer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.35230
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90827'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Unauthenticated Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus Unauthenticated Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE Plus Unauthenticated Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE Plus Unauthenticated Remote Code Execution Vulnerability. Netgear ProSAFE Plus is prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.26919
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90824'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear ProSAFE Plus XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear ProSAFE Plus XSS Vulnerability
+description: Palo Alto Networks detection for Netgear ProSAFE Plus XSS Vulnerability. Netgear ProSAFE Plus is prone to a stored XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stored XSS vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2020.35228
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90825'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear Routers Arbitrary Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear Routers Arbitrary Command Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Netgear Routers Arbitrary Command Injection Vulnerability
+description: Palo Alto Networks detection for Netgear Routers Arbitrary Command Injection Vulnerability. Netgear R7000, firmware version 1.0.7.2_1.1.93 and possibly earlier, and R6400, firmware version 1.0.1.12_1.0.11 and possibly earlier, contain an arbitrary command injection vulnerability. By convincing a user to visit a specially crafted web site, a remote unauthenticated attacker may execute arbitrary commands with root privileges on affected routers.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30554'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear WNDR3400v3 Stack-Based Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netgear WNDR3400v3 Stack-Based Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netgear WNDR3400v3 Stack-Based Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Netgear WNDR3400v3 Stack-Based Buffer Overflow Vulnerability. Netgear WNDR3400v3 is prone to a stack-based buffer overflow vulnerability while parsing certain crafted SSDP requests. The vulnerability is due to the lack of proper checks on SSDP requests, leading to an exploitable stack-based buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted SSDP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2019.14363
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91143'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netlink GPON Router and OptiLink ONT1GEW GPON Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netlink GPON Router and OptiLink ONT1GEW GPON Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netlink GPON Router and OptiLink ONT1GEW GPON Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Netlink GPON Router and OptiLink ONT1GEW GPON Remote Command Execution Vulnerability. Netlink GPON Router and OptiLink ONT1GEW GPON are prone to a remote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.8958
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '57868'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netscape iPlanet Search NS-Query-Pat Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netscape iPlanet Search NS-Query-Pat Directory Traversal Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netscape iPlanet Search NS-Query-Pat Directory Traversal Vulnerability
+description: Palo Alto Networks detection for Netscape iPlanet Search NS-Query-Pat Directory Traversal Vulnerability. iPlanet web server 6.0 SP2 and 4.1 SP9, and Netscape Enterprise Server 3.6 are prone to an information disclosure vulnerability while handling certain crafted HTTP requests. The vulnerability is due to the improper sanitization of directory traversal patterns passed to the NS-query-pat parameter. An attacker could send a crafted HTTP request to read arbitrary files on the vulnerable server.
+tags:
+- cve.2002.1042
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '33783'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netsia SEBA Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Netsia SEBA Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Netsia SEBA Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Netsia SEBA Information Disclosure Vulnerability. Netsia SEBA is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in the HTTP request, leading to an exploitable information disclosure. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure of the server.
+tags:
+- cve.2021.3113
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90990'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Network Time Protocol Windows Daemon Denial of Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Network Time Protocol Windows Daemon Denial of Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Network Time Protocol Windows Daemon Denial of Service Vulnerability
+description: Palo Alto Networks detection for Network Time Protocol Windows Daemon Denial of Service Vulnerability. The Network Time Protocol Windows Daemon is prone to a denial-of-service vulnerability while parsing certain crafted UDP requests. The vulnerability is due to the lack of proper checks on the size of UDP packets, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending an overly large UDP packet. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2016.9312
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '30353'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nginx Ingress Kubernetes Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nginx Ingress Kubernetes Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Nginx Ingress Kubernetes Command Injection Vulnerability
+description: Palo Alto Networks detection for Nginx Ingress Kubernetes Command Injection Vulnerability. Nginx Ingress Kubernetes is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable code execution. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.5044
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95112'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nginx Off-by-One Error Heap Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nginx Off-by-One Error Heap Memory Corruption Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Nginx Off-by-One Error Heap Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Nginx Off-by-One Error Heap Memory Corruption Vulnerability. Nginx is prone to an off-by-one heap corruption vulnerability while parsing certain crafted DNS responses. The vulnerability is due to the lack of proper checks on DNS responses, leading to an exploitable off-by-one heap corruption vulnerability. An attacker could exploit the vulnerability by sending crafted DNS responses. A successful attack could lead to remote code execution with the privileges of the Nginx server.
+tags:
+- cve.2021.23017
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91194'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Active Directory Enumeration Via NTLM.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Active Directory Enumeration Via NTLM.yaml
@@ -1,0 +1,15 @@
+title: Nmap Active Directory Enumeration Via NTLM
+description: Palo Alto Networks detection for Nmap Active Directory Enumeration Via NTLM. This signature indicates that an attacker is trying to collect information about the network by using the Nmap Active Directory Enumeration Via NTLM.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '92805'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Aggressive Option Print Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Aggressive Option Print Discovery.yaml
@@ -1,0 +1,15 @@
+title: Nmap Aggressive Option Print Discovery
+description: Palo Alto Networks detection for Nmap Aggressive Option Print Detection. This signature is detecting nmap aggressive option print.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94318'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Service Discovery.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nmap Service Discovery.yaml
@@ -1,0 +1,15 @@
+title: Nmap Service Discovery
+description: Palo Alto Networks detection for Nmap Service Detection. This signature is detecting nmap service scanning.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '94317'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Node.js Code Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Node.js Code Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Node.js Code Injection Vulnerability
+description: Palo Alto Networks detection for Node.js Code Injection Vulnerability. Node.js is prone to a code injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable code injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.28502
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '91119'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NodeBB Socket.io Event Name Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NodeBB Socket.io Event Name Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: NodeBB Socket.io Event Name Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for NodeBB Socket.io Event Name Denial-of-Service Vulnerability. NodeBB is prone to a denial-of-service vulnerability while parsing certain crafted Socket.IO requests. The vulnerability is due to the lack of proper checks on Socket.IO requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted Socket.IO requests. A successful attack could lead to denial-of-service with the privileges of the server.
+tags:
+- cve.2023.30591
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95774'
+    - '95773'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NodeJS WS HTTP Header Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NodeJS WS HTTP Header Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: NodeJS WS HTTP Header Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for NodeJS WS HTTP Header Denial-of-Service Vulnerability. NodeJS WS is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to denial-of-service with the privileges of the server.
+tags:
+- cve.2024.37890
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95723'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nodejs HTTP Request Smuggling Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nodejs HTTP Request Smuggling Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Nodejs HTTP Request Smuggling Vulnerability
+description: Palo Alto Networks detection for Nodejs HTTP Request Smuggling Vulnerability. Nodejs is prone to a HTTP request smuggling vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks in HTTP requests, leading to an exploitable HTTP request smuggling. An attacker could exploit the vulnerability by sending a crafted HTTP request.
+tags:
+- cve.2022.32215
+- cve.2020.8287
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '93243'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nokia PC Suite Video Manager Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nokia PC Suite Video Manager Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Nokia PC Suite Video Manager Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Nokia PC Suite Video Manager Denial-of-Service Vulnerability. Nokia PC Suite Video Manager is prone to a buffer overflow vulnerability while parsing certain crafted MP4 files. The vulnerability is due to the lack of proper checks on MP4 files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted MP4 file. A successful attack could lead to denial-of-service with the privileges of the currently logged-in user.
+tags:
+- cve.2012.2442
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95615'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant HTTP Traffic on Port 80.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant HTTP Traffic on Port 80.yaml
@@ -1,0 +1,15 @@
+title: Non-RFC Compliant HTTP Traffic on Port 80
+description: Palo Alto Networks detection for Non-RFC Compliant HTTP Traffic on Port 80. This signature detects suspicious and non-RFC compliant HTTP traffic on port 80. This could be associated with applications sending non HTTP traffic using port 80 or indicate possible malicious activity.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95356'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MS-DS-SMB Traffic on Port 445.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MS-DS-SMB Traffic on Port 445.yaml
@@ -1,0 +1,15 @@
+title: Non-RFC Compliant MS-DS-SMB Traffic on Port 445
+description: Palo Alto Networks detection for Non-RFC Compliant MS-DS-SMB Traffic on Port 445. This signature detects suspicious and non-RFC compliant MS-DS-SMB traffic on port 445. This could be associated with applications sending non MS-DS-SMB traffic using port 445 or indicate possible malicious activity.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95608'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MS-RDP Traffic on Port 3389.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MS-RDP Traffic on Port 3389.yaml
@@ -1,0 +1,17 @@
+title: Non-RFC Compliant MS-RDP Traffic on Port 3389
+description: Palo Alto Networks detection for Non-RFC Compliant MS-RDP Traffic on Port 3389. This signature detects suspicious and non-RFC compliant MS-RDP traffic on port 3389. This could be associated with applications sending non MS-RDP traffic using port 3389 or indicates possible malicious activity.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId:
+    - '95511'
+    - '95524'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MSSQL-DB Traffic on Port 1433.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MSSQL-DB Traffic on Port 1433.yaml
@@ -1,0 +1,15 @@
+title: Non-RFC Compliant MSSQL-DB Traffic on Port 1433
+description: Palo Alto Networks detection for Non-RFC Compliant MSSQL-DB Traffic on Port 1433. This signature detects suspicious and non-RFC compliant MSSQL-DB traffic on port 1433. This could be associated with applications sending non MSSQL-DB traffic using port 1433 or indicates possible malicious activity.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95534'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MYSQL Traffic on Port 3306.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-RFC Compliant MYSQL Traffic on Port 3306.yaml
@@ -1,0 +1,15 @@
+title: Non-RFC Compliant MYSQL Traffic on Port 3306
+description: Palo Alto Networks detection for Non-RFC Compliant MYSQL Traffic on Port 3306. This signature detects suspicious and non-RFC compliant MYSQL traffic on port 3306. This could be associated with applications sending non MYSQL traffic using port 3306 or indicates possible malicious activity.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95535'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-TLS Traffic On Port 443.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Non-TLS Traffic On Port 443.yaml
@@ -1,0 +1,15 @@
+title: Non-TLS Traffic On Port 443
+description: Palo Alto Networks detection for Non-TLS Traffic On Port 443. This signature detects non-TLS traffic on port 443 based on the RFC of TLS.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95479'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nordex NC2 SCADA 16 XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nordex NC2 SCADA 16 XSS Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Nordex NC2 SCADA 16 XSS Vulnerability
+description: Palo Alto Networks detection for Nordex NC2 SCADA 16 Cross-Site Scripting Vulnerability. Nordex NC2 Wind Farm Portal application is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on parameters in HTTP requests, leading to an exploitable cross-site scripting. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2015.6477
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '57631'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nortek Linear eMerge E3 Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nortek Linear eMerge E3 Command Injection Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Nortek Linear eMerge E3 Command Injection Vulnerability
+description: Palo Alto Networks detection for Nortek Linear eMerge E3 Command Injection Vulnerability. Nortek Linear eMerge E3 is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2024.9441
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '95764'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell File Reporter FSFUI Arbitrary File Retrieval Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell File Reporter FSFUI Arbitrary File Retrieval Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Novell File Reporter FSFUI Arbitrary File Retrieval Vulnerability
+description: Palo Alto Networks detection for Novell File Reporter FSFUI Arbitrary File Retrieval Vulnerability. Novell File Reporter is prone to a arbitrary file retrieval vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable arbitrary file retrieval vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2012.4958
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '54119'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell ZENWorks Asset Management Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell ZENWorks Asset Management Information Disclosure Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: Novell ZENWorks Asset Management Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Novell ZENWorks Asset Management Information Disclosure Vulnerability. Novell ZENWorks is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to hard coded default credentials in the Rtrlet Web Application leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to an attacker retrieving any file from the remote file system with the privileges of the system.
+tags:
+- cve.2012.4933
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '35600'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell ZENworks Mobile Management XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Novell ZENworks Mobile Management XSS Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Novell ZENworks Mobile Management XSS Vulnerability
+description: Palo Alto Networks detection for Novell ZENworks Mobile Management Cross-Site Scripting Vulnerability. Novell ZENworks Configuration Management is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on parameter in the HTTP request, leading to an exploitable code execution. A remote attacker can exploit this vulnerability by enticing a user to click on a maliciously crafted link. This can lead to arbitrary script code execution in the context of the affected user.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '39766'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NuCom 11N Wireless Router Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NuCom 11N Wireless Router Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: NuCom 11N Wireless Router Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for NuCom 11N Wireless Router Privilege Escalation Vulnerability. NuCom 11N Wireless Router is prone to a privilege escalation vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable privilege escalation vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90921'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OneDev Platform AttachmentUploadServet Insecure Deserialization Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OneDev Platform AttachmentUploadServet Insecure Deserialization Vulnerability.yaml
@@ -1,0 +1,16 @@
+title: OneDev Platform AttachmentUploadServet Insecure Deserialization Vulnerability
+description: Palo Alto Networks detection for OneDev OneDev Platform AttachmentUploadServet Insecure Deserialization Vulnerability. OneDev OneDev Platform is prone to an insecure deserialization vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure deserialization vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to code execution.
+tags:
+- cve.2021.21242
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90806'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Online Book Store SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Online Book Store SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Online Book Store SQL Injection Vulnerability
+description: Palo Alto Networks detection for Online Book Store SQL Injection Vulnerability. Online Book Store is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90275'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Online Shopping Alphaware SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Online Shopping Alphaware SQL Injection Vulnerability.yaml
@@ -1,0 +1,15 @@
+title: Online Shopping Alphaware SQL Injection Vulnerability
+description: Palo Alto Networks detection for Online Shopping Alphaware SQL Injection Vulnerability. Online Shopping Alphaware is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90274'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ntopng Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ntopng Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: ntopng Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for ntopng Authentication Bypass Vulnerability. ntopng is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to authentication bypass and code execution with the privileges of the server.
+tags:
+- cve.2021.28073
+- cve.2021.28074
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: PALO ALTO NETWORKS
+detection:
+  subname:
+    eventSubName: vulnerability
+  rule:
+    ruleId: '90917'
+  condition: subname and rule
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Added multiple Sigma rule YAML files for Palo Alto Networks PAN-OS Firewall third-party log detections. These rules cover a wide range of vulnerabilities including command injection, buffer overflow, insecure deserialization, SSRF, XSS, SQL injection, denial-of-service, information disclosure, and remote code execution for products such as NETGEAR, NI FlexLogger, NPM, NSFocus, NVIDIA CUDA Toolkit, Netgear ProSAFE, Node.js, Nginx, Nmap, and others.