### PR TITLE
PAN - New CDFs

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AC3200 Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AC3200 Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ASUS RT-AC3200 Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for ASUS RT-AC3200 Cross-Site Scripting Vulnerability. ASUS RT-AC3200 is prone to an XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.14710
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91310'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AC3200 Stack Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS RT-AC3200 Stack Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ASUS RT-AC3200 Stack Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for ASUS RT-AC3200 Stack Buffer Overflow Vulnerability. ASUS RT-AC3200 is prone to a stack buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stack buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.14712
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91309'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS or Netcore Router Default Credential Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ASUS or Netcore Router Default Credential Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ASUS or Netcore Router Default Credential Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for ASUS/Netcore Router Default Credential Remote Code Execution Vulnerability. ASUS/Netcore is prone to a remote code execution vulnerability while parsing certain crafted requests. The vulnerability is due to the lack of proper checks in the UDP packet, leading to an exploitable remote code execution. An attacker could exploit the vulnerability by sending a crafted UDP packet. A successful attack could lead to remote code execution with the privileges of the current logged-in user.
+tags:
+- cve.2014.9583
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - alert
+    ruleId: '39438'
+    severity: '6'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Belkin N750 Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Belkin N750 Buffer Overflow Vulnerability. Belkin N750 is prone to a buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.1145
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91306'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Privilege Escalation Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Privilege Escalation Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Belkin N750 Privilege Escalation Vulnerability
+description: Palo Alto Networks detection for Belkin N750 Privilege Escalation Vulnerability. Belkin N750 is prone to a privilege escalation vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable privilege escalation vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2018.1146
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91307'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Belkin N750 Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Belkin N750 Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for Belkin N750 Remote Command Execution Vulnerability. Belkin N750 is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2018.1144
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91305'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Linksys E4200 Router XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Linksys E4200 Router XSS Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Cisco Linksys E4200 Router XSS Vulnerability
+description: Palo Alto Networks detection for Cisco Linksys E4200 Router XSS Vulnerability. Cisco Linksys E4200 Router is prone to a XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2013.2679
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91271'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Linksys Router Local File Inclusion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Linksys Router Local File Inclusion Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Cisco Linksys Router Local File Inclusion Vulnerability
+description: Palo Alto Networks detection for Cisco Linksys Router Local File Inclusion Vulnerability. Cisco Linksys Router is prone to a local file inclusion vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable local file inclusion vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2013.2678
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91265'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Modeling Labs Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco Modeling Labs Command Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Cisco Modeling Labs Command Injection Vulnerability
+description: Palo Alto Networks detection for Cisco Modeling Labs Command Injection Vulnerability. Cisco Modeling Labs is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution.
+tags:
+- cve.2021.1531
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91298'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV320 or RV325 Router Unauthenticated Configuration Export Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Cisco RV320 or RV325 Router Unauthenticated Configuration Export Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: Cisco RV320 or RV325 Router Unauthenticated Configuration Export Vulnerability
+description: Palo Alto Networks detection for Cisco RV320/RV325 Router Unauthenticated Configuration Export Vulnerability. Cisco RV320/RV325 Router is prone to an information disclosure vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2019.1653
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId: '55025'
+    severity: '8'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Contiki Operating System Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Contiki Operating System Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Contiki Operating System Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Contiki Operating System Cross-Site Scripting Vulnerability. Contiki Operating System is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2017.7296
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91264'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/D-Link Cookie Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/D-Link Cookie Command Execution Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: D-Link Cookie Command Execution Vulnerability
+description: Palo Alto Networks detection for D-Link Cookie Command Execution Vulnerability. D-Link is prone to a command injection vulnerability while parsing certain crafted CBT files. The vulnerability is due to the lack of proper checks on CBT files, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted CBT file. A successful attack could lead to command execution.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91289'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/DocumentServer Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/DocumentServer Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: DocumentServer Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for DocumentServer Remote Code Execution Vulnerability. DocumentServer is prone to a emote code execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable emote code execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.25833
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91316'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Draytek Vigor Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Draytek Vigor Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Draytek Vigor Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Draytek Vigor Buffer Overflow Vulnerability. Draytek Vigor is prone to a stack-based buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stack-based buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.14473
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91274'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Draytek Vigor Remote Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Draytek Vigor Remote Command Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Draytek Vigor Remote Command Injection Vulnerability
+description: Palo Alto Networks detection for Draytek Vigor Remote Command Injection Vulnerability. Draytek Vigor is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.14472
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91275'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Drobo 5N2 Insufficient Authentication Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Drobo 5N2 Insufficient Authentication Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Drobo 5N2 Insufficient Authentication Vulnerability
+description: Palo Alto Networks detection for Drobo 5N2 Insufficient Authentication Vulnerability. Drobo 5N2 is prone to an insufficient authentication vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable insufficient authentication vulnerability. An attacker could exploit the vulnerability by sending a crafted TCP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2018.14709
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91278'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Email Link.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Email Link.yaml
@@ -1,0 +1,19 @@
+title: Email Link
+description: Palo Alto Networks detection for Email Link. This file type is used to enable the email link forwarding feature.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId: '52143'
+    severity: '8'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FTP login Brute Force attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FTP login Brute Force attempt.yaml
@@ -1,0 +1,19 @@
+title: FTP login Brute Force attempt
+description: Palo Alto Networks detection for FTP login Brute Force attempt. This event indicates that someone is using a brute force attack to gain access to an FTP server. An FTP brute force attack is a method of defeating the cryptographic scheme by trying a large number of possible username and passwords. Refer to Palo Alto Networks documentation to learn more about brute force signatures and to customize the action and trigger conditions for a brute force signature.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId: '40001'
+    severity: '8'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FarLinX X25 Gateway Directory Traversal Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/FarLinX X25 Gateway Directory Traversal Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: FarLinX X25 Gateway Directory Traversal Vulnerability
+description: Palo Alto Networks detection for FarLinX X25 Gateway Directory Traversal Vulnerability. FarLinX X25 Gateway is prone to a directory traversal vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable directory traversal vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2014.7174
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91272'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/GitLab SSRF Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/GitLab SSRF Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: GitLab SSRF Vulnerability
+description: Palo Alto Networks detection for GitLab SSRF Vulnerability. GitLab is prone to an SSRF vulnerability while parsing certain crafted HTTTP requests. The vulnerability is due to the lack of proper checks on HTTTP requests, leading to an exploitable SSRF vulnerability. An attacker could exploit the vulnerability by sending crafted HTTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.22214
+- cve.2021.22175
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91296'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/GoAhead Web Server Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/GoAhead Web Server Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: GoAhead Web Server Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for GoAhead Web Server Authentication Bypass Vulnerability. GoAhead Web Server is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure with the privileges of the server.
+tags:
+- cve.2020.15688
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91283'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Google Chrome Out-of-Bounds Write Vulnerability - Heap Overflow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Google Chrome Out-of-Bounds Write Vulnerability - Heap Overflow.yaml
@@ -1,0 +1,22 @@
+title: Google Chrome Out-of-Bounds Write Vulnerability - Heap Overflow
+description: Palo Alto Networks detection for Google Chrome Out-of-Bounds Write Vulnerability. Google Chrome is prone to a heap overflow vulnerability while parsing certain crafted BMP files. The vulnerability is due to the lack of proper checks on BMP files, leading to an exploitable heap overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to memory corruption condition.
+tags:
+- cve.2024.1283
+- cve.2024.7965
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId:
+    - '95234'
+    - '95618'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP Blind SQL Injection Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP Blind SQL Injection Attempt.yaml
@@ -1,0 +1,17 @@
+title: HTTP Blind SQL Injection Attempt
+description: Palo Alto Networks detection for HTTP Blind SQL Injection Attempt. SQL injection is a technique that exploits a security vulnerability occurring in the database layer of an application. The vulnerability is present when user input is either incorrectly filtered for string literal escape characters embedded in SQL statements or user input is not strongly typed and thereby unexpectedly executed. It is, in fact, an instance of a more general class of vulnerabilities that can occur whenever one programming or scripting language is embedded inside another.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91315'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP etc-passwd Access Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/HTTP etc-passwd Access Attempt.yaml
@@ -1,0 +1,22 @@
+title: HTTP etc-passwd Access Attempt
+description: Palo Alto Networks detection for HTTP /etc/passwd Access Attempt. This signature detects /etc/passwd access attempt used by attackers to access sensitive information.
+tags:
+- cve.2019.8903
+- cve.2020.5410
+- cve.2022.31793
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId: '35107'
+    severity: '8'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Jenkins Credentials Plugin Reflected Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Jenkins Credentials Plugin Reflected Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Jenkins Credentials Plugin Reflected Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Jenkins Credentials Plugin Reflected Cross-Site Scripting Vulnerability. Jenkins Credentials Plugin is prone to a reflected cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable reflected cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.21648
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91267'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Kemp Load Master Bash Script Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Kemp Load Master Bash Script Injection Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Kemp Load Master Bash Script Injection Vulnerability
+description: Palo Alto Networks detection for Kemp Load Master Bash Script Injection Vulnerability. Kemp LoadMaster is prone to a bash script injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable bash script injection vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to command execution.
+tags:
+- cve.2014.5287
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91302'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/LDAP User Login Brute Force Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/LDAP User Login Brute Force Attempt.yaml
@@ -1,0 +1,19 @@
+title: LDAP User Login Brute Force Attempt
+description: Palo Alto Networks detection for LDAP User Login Brute Force Attempt. This event indicates that someone is using a brute force attack to gain access to windows through ldap bind request.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId: '40005'
+    severity: '8'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Meetecho Janus Stack Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Meetecho Janus Stack Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Meetecho Janus Stack Overflow Vulnerability
+description: Palo Alto Networks detection for Meetecho Janus Stack Overflow Vulnerability. Meetecho Janus is prone to a stack overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stack overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.13901
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91321'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Browser Memory Corruption Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Browser Memory Corruption Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Microsoft Browser Memory Corruption Vulnerability
+description: Palo Alto Networks detection for Microsoft Browser Memory Corruption Vulnerability. Microsoft Internet Explorer and Edge are prone to a memory corruption vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable memory corruption vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to remote code execution with the privileges of the currently logged-in user.
+tags:
+- cve.2016.3247
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91322'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Edge Universal Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Edge Universal Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Microsoft Edge Universal Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for Microsoft Edge Universal Cross-Site Scripting Vulnerability. Microsoft Edge is prone to a universal cross-site scripting vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable universal cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to memory corruption condition with the privileges of the currently logged-in user.
+tags:
+- cve.2021.34506
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91308'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Excel Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Excel Information Disclosure Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Microsoft Excel Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Microsoft Excel Information Disclosure Vulnerability. Microsoft Office is prone to an information disclosure vulnerability while parsing certain crafted EML files. The vulnerability is due to the lack of proper checks on EML files, leading to an exploitable information disclosure vulnerability. An attacker could exploit the vulnerability by sending a crafted EML file. A successful attack could lead to information disclosure with the privileges of the currently logged-in user.
+tags:
+- cve.2021.31174
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91292'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Office Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Office Information Disclosure Vulnerability.yaml
@@ -1,0 +1,21 @@
+title: Microsoft Office Information Disclosure Vulnerability
+description: Palo Alto Networks detection for Microsoft Office Information Disclosure Vulnerability. Microsoft Office is prone to an information disclosure vulnerability while parsing certain crafted Office documents. The vulnerability is due to the lack of proper checks on objects in memory, leading to an exploitable information disclosure. An attacker could exploit the vulnerability by enticing a user to open a crafted Office document. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.31178
+- cve.2021.31174
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91293'
+    - '91291'
+    - '91290'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Teams Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Microsoft Teams Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Microsoft Teams Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for Microsoft Teams Remote Code Execution Vulnerability. Microsoft Teams is prone to a remote code execution vulnerability while parsing certain crafted HTML files. The vulnerability is due to the lack of proper checks on HTML files, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted HTML file. A successful attack could lead to remote code execution.
+tags:
+- cve.2020.17091
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91320'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Monitorr Insecure File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Monitorr Insecure File Upload Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Monitorr Insecure File Upload Vulnerability
+description: Palo Alto Networks detection for Monitorr Insecure File Upload Vulnerability. Monitorr is prone to an insecure file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable insecure file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.28871
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91269'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NUUO NVRmini2 Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NUUO NVRmini2 Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: NUUO NVRmini2 Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for NUUO NVRmini2 Buffer Overflow Vulnerability. NUUO NVRmini2 s prone to a stack-based buffer overflow vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable stack-based buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2016.5680
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91282'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NUUO NVRmini2 Information Disclosure Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/NUUO NVRmini2 Information Disclosure Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: NUUO NVRmini2 Information Disclosure Vulnerability
+description: Palo Alto Networks detection for NUUO NVRmini2 Information Disclosure Vulnerability. NUUO NVRmini2 is prone to an information vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable information vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2016.5677
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91281'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios XI XSS Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Nagios XI XSS Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Nagios XI XSS Vulnerability
+description: Palo Alto Networks detection for Nagios XI XSS Vulnerability. Nagios XI is prone to an XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.25299
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91287'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ONLYOFFICE Document Server Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ONLYOFFICE Document Server Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ONLYOFFICE Document Server Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for ONLYOFFICE Document Server Buffer Overflow Vulnerability. ONLYOFFICE Document Server is prone to a buffer overflow vulnerability while parsing certain crafted BMP files. The vulnerability is due to the lack of proper checks on BMP files, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending a crafted BMP file. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.25832
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91318'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ONLYOFFICE Document Server Remote Code Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ONLYOFFICE Document Server Remote Code Execution Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: ONLYOFFICE Document Server Remote Code Execution Vulnerability
+description: Palo Alto Networks detection for ONLYOFFICE Document Server Remote Code Execution Vulnerability. ONLYOFFICE Document Server is prone to a remote code execution vulnerability while parsing certain crafted PPTT files. The vulnerability is due to the lack of proper checks on PPTT files, leading to an exploitable remote code execution vulnerability. An attacker could exploit the vulnerability by sending a crafted PPTT file. A successful attack could lead to remote code execution.
+tags:
+- cve.2021.25831
+- cve.2021.25830
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91317'
+    - '91319'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenClinic GA SQL Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/OpenClinic GA SQL Injection Vulnerability.yaml
@@ -1,0 +1,26 @@
+title: OpenClinic GA SQL Injection Vulnerability
+description: Palo Alto Networks detection for OpenClinic GA SQL Injection Vulnerability. OpenClinic GA is prone to a SQL injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable SQL injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.27233
+- cve.2020.27234
+- cve.2020.27235
+- cve.2020.27236
+- cve.2020.27237
+- cve.2020.27238
+- cve.2020.27239
+- cve.2020.27240
+- cve.2020.27241
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91266'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Oracle Sales Offline Denial-of-Service Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Oracle Sales Offline Denial-of-Service Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: Oracle Sales Offline Denial-of-Service Vulnerability
+description: Palo Alto Networks detection for Oracle Sales Offline Denial-of-Service Vulnerability. Oracle Sales Offline is prone to a denial-of-service vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable denial-of-service vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to denial-of-service.
+tags:
+- cve.2021.2189
+- cve.2021.2190
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91277'
+    - '91312'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Phone Shop Sales Management System Arbitrary File Upload Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Phone Shop Sales Management System Arbitrary File Upload Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: Phone Shop Sales Management System Arbitrary File Upload Vulnerability
+description: Palo Alto Networks detection for Phone Shop Sales Management System Unauthenticated Arbitrary File Upload Vulnerability. Phone Shop Sales Management System is prone to an unauthenticated arbitrary file upload vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable unauthenticated arbitrary file upload vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91268'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ruckus Remote Authentication Bypass Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Ruckus Remote Authentication Bypass Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Ruckus Remote Authentication Bypass Vulnerability
+description: Palo Alto Networks detection for Ruckus Remote Authentication Bypass Vulnerability. Ruckus is prone to an authentication bypass vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable authentication bypass vulnerability. An attacker could exploit the vulnerability by sending a crafted HTTP request. A successful attack could lead to information disclosure.
+tags:
+- cve.2020.26879
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91285'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/TerraMaster TOS Remote Command Execution Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/TerraMaster TOS Remote Command Execution Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: TerraMaster TOS Remote Command Execution Vulnerability
+description: Palo Alto Networks detection for TerraMaster TOS Remote Command Execution Vulnerability. TerraMaster TOS is prone to a remote command execution vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable remote command execution vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2020.28188
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91313'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Wazuh Wazuh host-deny Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Wazuh Wazuh host-deny Command Injection Vulnerability.yaml
@@ -1,0 +1,20 @@
+title: Wazuh Wazuh host-deny Command Injection Vulnerability
+description: Palo Alto Networks detection for Wazuh Wazuh host-deny Command Injection Vulnerability. Wazuh is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2023.50260
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - reset-both
+    - reset-server
+    - drop
+    ruleId:
+    - '95541'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WebSVN Command Injection Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WebSVN Command Injection Vulnerability.yaml
@@ -1,0 +1,19 @@
+title: WebSVN Command Injection Vulnerability
+description: Palo Alto Networks detection for WebSVN Command Injection Vulnerability. WebSVN is prone to a command injection vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable command injection vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.32305
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91513'
+    - '91280'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Wibu-Systems CodeMeter Buffer Overflow Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/Wibu-Systems CodeMeter Buffer Overflow Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: Wibu-Systems CodeMeter Buffer Overflow Vulnerability
+description: Palo Alto Networks detection for Wibu-Systems CodeMeter Buffer Overflow Vulnerability. Wibu-Systems CodeMeter is prone to a buffer overflow vulnerability while parsing certain crafted TCP requests. The vulnerability is due to the lack of proper checks on TCP requests, leading to an exploitable buffer overflow vulnerability. An attacker could exploit the vulnerability by sending crafted TCP requests. A successful attack could lead to information disclosure.
+tags:
+- cve.2021.20093
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91288'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Stop Spammers Plugin Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/WordPress Stop Spammers Plugin Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: WordPress Stop Spammers Plugin Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for WordPress Stop Spammers Plugin Cross-Site Scripting Vulnerability. WordPress Stop Spammer is prone to a cross-site scripting vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable cross-site scripting vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags:
+- cve.2021.24245
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91284'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZTE WLAN Router MF253V Cross-Site Scripting Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ZTE WLAN Router MF253V Cross-Site Scripting Vulnerability.yaml
@@ -1,0 +1,17 @@
+title: ZTE WLAN Router MF253V Cross-Site Scripting Vulnerability
+description: Palo Alto Networks detection for ZTE WLAN Router MF253V Cross-Site Scripting Vulnerability. ZTE WLAN Router MF253V is prone to an XSS vulnerability while parsing certain crafted HTTP requests. The vulnerability is due to the lack of proper checks on HTTP requests, leading to an exploitable XSS vulnerability. An attacker could exploit the vulnerability by sending crafted HTTP requests. A successful attack could lead to remote code execution with the privileges of the server.
+tags: []
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    ruleId:
+    - '91276'
+    act:
+    - alert
+  condition: mappingtable
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ht-dig Arbitrary File Inclusion Vulnerability.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/palo_alto_networks/PAN-OS/Firewall/ht-dig Arbitrary File Inclusion Vulnerability.yaml
@@ -1,0 +1,18 @@
+title: ht-dig Arbitrary File Inclusion Vulnerability
+description: Palo Alto Networks detection for ht-dig Arbitrary File Inclusion Vulnerability. The ht-dig program is prone to a arbitrary file reading vulnerability while parsing certain crafted parameters.The vulnerability is due to the lack of proper checks on htsearch field in the http request, leading to a arbitrary file exposure vulnerability.An attacker could exploit the vulnerability by sending a crafted argument to htsearch cgi. A successful attack could lead to read any file existed in the server.
+tags:
+- cve.2000.0208
+logsource:
+  definition: THIRDPARTY_THIRDPARTY
+  category: THIRD_PARTY_LOG
+  product: Palo Alto Networks
+detection:
+  mappingtable:
+    eventSubName: vulnerability
+    act:
+    - alert
+    ruleId: '30939'
+    severity: '6'
+  condition: mappingtable
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Introduced multiple Sigma rule YAML files for Palo Alto Networks PAN-OS firewall third-party log detections. These rules cover a wide range of vulnerabilities including XSS, buffer overflow, command injection, authentication bypass, brute force attempts, information disclosure, and remote code execution for various products and services. Each rule provides detection logic, relevant CVE tags, and mapping for alerting actions.