### PR TITLE
[CISCO Meraki] New CDFs

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Deauthentication.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Deauthentication.yaml
@@ -1,0 +1,14 @@
+title: 802.1X Deauthentication
+description: Cisco Meraki detection for 802.1X deauthentication. Detects Meraki switch events where a device is deauthenticated from an 802.1X protected port.
+tags:
+    - mitre.t1110
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*8021x_deauth*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Deauthentication.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Deauthentication.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1110
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*8021x_deauth*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Failed Authentication Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Failed Authentication Attempt.yaml
@@ -1,0 +1,14 @@
+title: 802.1X Failed Authentication Attempt
+description: Cisco Meraki detection for 802.1X failed authentication attempt. Detects Meraki wireless events where a client fails 802.1X/EAP authentication.
+tags:
+    - mitre.t1110
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*8021x_eap_failure*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Failed Authentication Attempt.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/802.1X Failed Authentication Attempt.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1110
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*8021x_eap_failure*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Blocked DHCP Server Response.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Blocked DHCP Server Response.yaml
@@ -1,0 +1,14 @@
+title: Blocked DHCP Server Response
+description: Cisco Meraki detection for Blocked DHCP server response. Detects Meraki events where a DHCP server response is identified as rogue and blocked.
+tags:
+    - mitre.t1557
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*Blocked DHCP server response*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Blocked DHCP Server Response.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Blocked DHCP Server Response.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1557
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*Blocked DHCP server response*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 1 (IKE_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 1 (IKE_SA) Tunnel.yaml
@@ -1,0 +1,16 @@
+title: Destroying Phase 1 (IKE_SA) Tunnel
+description: Cisco Meraki detection for Destroying Phase 1 (IKE_SA) tunnel. Detects Meraki MX VPN logs indicating Phase 1 (IKE_SA) tunnel teardown.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*deleting*'
+    string_condition_1:
+        vendorParsed.msg: '*IKE_SA*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 1 (IKE_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 1 (IKE_SA) Tunnel.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*deleting*'
     string_condition_1:
         vendorParsed.msg: '*IKE_SA*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 2 (CHILD_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 2 (CHILD_SA) Tunnel.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*closing*'
     string_condition_1:
         vendorParsed.msg: '*CHILD_SA*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 2 (CHILD_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Destroying Phase 2 (CHILD_SA) Tunnel.yaml
@@ -1,0 +1,16 @@
+title: Destroying Phase 2 (CHILD_SA) Tunnel
+description: Cisco Meraki detection for Destroying Phase 2 (CHILD_SA) tunnel. Detects Meraki MX VPN logs indicating Phase 2 (CHILD_SA) data tunnel teardown.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*closing*'
+    string_condition_1:
+        vendorParsed.msg: '*CHILD_SA*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 1 (IKE_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 1 (IKE_SA) Tunnel.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*IKE_SA*'
     string_condition_1:
         vendorParsed.msg: '*established*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 1 (IKE_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 1 (IKE_SA) Tunnel.yaml
@@ -1,0 +1,16 @@
+title: Establishing Phase 1 (IKE_SA) Tunnel
+description: Cisco Meraki detection for Establishing Phase 1 (IKE_SA) tunnel. Detects Meraki MX VPN logs indicating Phase 1 (IKE_SA) tunnel establishment.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*IKE_SA*'
+    string_condition_1:
+        vendorParsed.msg: '*established*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 2 (CHILD_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 2 (CHILD_SA) Tunnel.yaml
@@ -1,0 +1,16 @@
+title: Establishing Phase 2 (CHILD_SA) Tunnel
+description: Cisco Meraki detection for Establishing Phase 2 (CHILD_SA) tunnel. Detects Meraki MX VPN logs indicating Phase 2 (CHILD_SA) data tunnel establishment.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*CHILD_SA*'
+    string_condition_1:
+        vendorParsed.msg: '*established*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 2 (CHILD_SA) Tunnel.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Establishing Phase 2 (CHILD_SA) Tunnel.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*CHILD_SA*'
     string_condition_1:
         vendorParsed.msg: '*established*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/File Retrospective Malicious Disposition.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/File Retrospective Malicious Disposition.yaml
@@ -1,0 +1,16 @@
+title: File Retrospective Malicious Disposition
+description: Cisco Meraki detection for File retrospective malicious disposition. Detects retrospective AMP disposition updates where a previously allowed file is later determined to be malicious.
+tags:
+    - mitre.t1204
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.disposition: '*malicious*'
+    string_condition_1:
+        vendorParsed.action: '*allow*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/File Retrospective Malicious Disposition.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/File Retrospective Malicious Disposition.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1204
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.disposition: '*malicious*'
     string_condition_1:
         vendorParsed.action: '*allow*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Blocked).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Blocked).yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1190
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.decision: '*blocked*'
     string_condition_1:
         vendorParsed.signature|exists: true
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Blocked).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Blocked).yaml
@@ -1,0 +1,16 @@
+title: IDS Signature Matched (Blocked)
+description: Cisco Meraki detection for IDS signature matched (blocked). Detects events from Meraki MX where an IDS/IPS signature is present and the traffic was blocked.
+tags:
+    - mitre.t1190
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.decision: '*blocked*'
+    string_condition_1:
+        vendorParsed.signature|exists: true
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Egress).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Egress).yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1190
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.direction: '*egress*'
     string_condition_1:
         vendorParsed.signature|exists: true
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Egress).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Egress).yaml
@@ -1,0 +1,16 @@
+title: IDS Signature Matched (Egress)
+description: Cisco Meraki detection for IDS signature matched (egress). Detects IDS/IPS signature matches on egress traffic on Meraki MX.
+tags:
+    - mitre.t1190
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.direction: '*egress*'
+    string_condition_1:
+        vendorParsed.signature|exists: true
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Ingress).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Ingress).yaml
@@ -1,0 +1,16 @@
+title: IDS Signature Matched (Ingress)
+description: Cisco Meraki detection for IDS signature matched (ingress). Detects IDS/IPS signature matches on ingress traffic on Meraki MX.
+tags:
+    - mitre.t1190
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.direction: '*ingress*'
+    string_condition_1:
+        vendorParsed.signature|exists: true
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Ingress).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IDS Signature Matched (Ingress).yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1190
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.direction: '*ingress*'
     string_condition_1:
         vendorParsed.signature|exists: true
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IPsec-SA Established (Pre MX 15.12).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IPsec-SA Established (Pre MX 15.12).yaml
@@ -1,0 +1,16 @@
+title: IPsec-SA Established (Pre MX 15.12)
+description: Cisco Meraki detection for IPsec-SA established (pre MX 15.12). Detects legacy IKEv1 Phase 2 (IPsec-SA) establishment events on Meraki MX firmware prior to 15.12.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*IPsec-SA*'
+    string_condition_1:
+        vendorParsed.msg: '*established*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IPsec-SA Established (Pre MX 15.12).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/IPsec-SA Established (Pre MX 15.12).yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*IPsec-SA*'
     string_condition_1:
         vendorParsed.msg: '*established*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/ISAKMP-SA Established (Pre MX 15.12).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/ISAKMP-SA Established (Pre MX 15.12).yaml
@@ -1,0 +1,16 @@
+title: ISAKMP-SA Established (Pre MX 15.12)
+description: Cisco Meraki detection for ISAKMP-SA established (pre MX 15.12). Detects legacy IKEv1 Phase 1 (ISAKMP-SA) establishment events on Meraki MX firmware prior to 15.12.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*ISAKMP-SA*'
+    string_condition_1:
+        vendorParsed.msg: '*established*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/ISAKMP-SA Established (Pre MX 15.12).yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/ISAKMP-SA Established (Pre MX 15.12).yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*ISAKMP-SA*'
     string_condition_1:
         vendorParsed.msg: '*established*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/L3 Firewall Rule Matched.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/L3 Firewall Rule Matched.yaml
@@ -1,0 +1,16 @@
+title: L3 Firewall Rule Matched
+description: Cisco Meraki detection for L3 firewall rule matched. Detects Meraki MX Layer 3 firewall rule match events (allow/deny).
+tags:
+    - mitre.t1071
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.pattern: '*allow*'
+    string_condition_1:
+        vendorParsed.pattern: '*deny*'
+    condition: string_condition_0 or string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/L3 Firewall Rule Matched.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/L3 Firewall Rule Matched.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1071
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.pattern: '*allow*'
     string_condition_1:
         vendorParsed.pattern: '*deny*'
-    condition: string_condition_0 or string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 or string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Malicious File Blocked by AMP.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Malicious File Blocked by AMP.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1204
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.disposition: '*malicious*'
     string_condition_1:
         vendorParsed.action: '*block*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Malicious File Blocked by AMP.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Malicious File Blocked by AMP.yaml
@@ -1,0 +1,16 @@
+title: Malicious File Blocked by AMP
+description: Cisco Meraki detection for Malicious file blocked by AMP. Detects Meraki AMP events where a file is classified as malicious and blocked.
+tags:
+    - mitre.t1204
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.disposition: '*malicious*'
+    string_condition_1:
+        vendorParsed.action: '*block*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Rogue SSID Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Rogue SSID Detected.yaml
@@ -1,0 +1,14 @@
+title: Rogue SSID Detected
+description: Cisco Meraki detection for Rogue SSID detected. Detects Meraki wireless events indicating an unauthorized/rogue SSID has been detected.
+tags:
+    - mitre.t1557
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*rogue_ssid_detected*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Rogue SSID Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Rogue SSID Detected.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1557
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*rogue_ssid_detected*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/SSID Spoofing Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/SSID Spoofing Detected.yaml
@@ -1,0 +1,14 @@
+title: SSID Spoofing Detected
+description: Cisco Meraki detection for SSID spoofing detected. Detects Meraki wireless events where a device is broadcasting an organization SSID name without authorization.
+tags:
+    - mitre.t1557
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*ssid_spoofing_detected*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/SSID Spoofing Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/SSID Spoofing Detected.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1557
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*ssid_spoofing_detected*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Spanning-tree Guard State Change.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Spanning-tree Guard State Change.yaml
@@ -1,0 +1,16 @@
+title: Spanning-tree Guard State Change
+description: Cisco Meraki detection for Spanning-tree guard state change. Detects Meraki switch events where an unexpected STP BPDU triggers a guard state change/port block.
+tags:
+    - mitre.t1498
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*STP BPDU*'
+    string_condition_1:
+        vendorParsed.msg: '*blocked*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Spanning-tree Guard State Change.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Spanning-tree Guard State Change.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1498
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*STP BPDU*'
     string_condition_1:
         vendorParsed.msg: '*blocked*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/VPN Connectivity Change.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/VPN Connectivity Change.yaml
@@ -4,11 +4,13 @@ tags:
     - mitre.t1572
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*vpn_connectivity_change*'
-    condition: string_condition_0
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/VPN Connectivity Change.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/VPN Connectivity Change.yaml
@@ -1,0 +1,14 @@
+title: VPN Connectivity Change
+description: Cisco Meraki detection for VPN connectivity change. Detects Meraki MX events indicating a site-to-site VPN connectivity status change.
+tags:
+    - mitre.t1572
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*vpn_connectivity_change*'
+    condition: string_condition_0
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Virtual Router Collision.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Virtual Router Collision.yaml
@@ -1,0 +1,16 @@
+title: Virtual Router Collision
+description: Cisco Meraki detection for Virtual router collision. Detects Meraki events indicating VRRP packets with incompatible or conflicting configuration (virtual router collision).
+tags:
+    - mitre.t1557
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.msg: '*VRRP*'
+    string_condition_1:
+        vendorParsed.msg: '*incompatible configuration*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Virtual Router Collision.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Virtual Router Collision.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1557
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.msg: '*VRRP*'
     string_condition_1:
         vendorParsed.msg: '*incompatible configuration*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Wireless Packet Flood Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Wireless Packet Flood Detected.yaml
@@ -4,13 +4,15 @@ tags:
     - mitre.t1498
 logsource:
     category: THIRD_PARTY_LOG
-    product: Meraki
+    product: Cisco
     definition: THIRDPARTY_THIRDPARTY
 detection:
     string_condition_0:
         vendorParsed.type: '*device_packet_flood*'
     string_condition_1:
         vendorParsed.state: '*start*'
-    condition: string_condition_0 and string_condition_1
+    productName:
+        pname: 'Meraki'
+    condition: productName and string_condition_0 and string_condition_1
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Wireless Packet Flood Detected.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Cisco/Meraki/Wireless Packet Flood Detected.yaml
@@ -1,0 +1,16 @@
+title: Wireless Packet Flood Detected
+description: Cisco Meraki detection for Wireless packet flood detected. Detects Meraki wireless events consistent with packet flood/DoS activity.
+tags:
+    - mitre.t1498
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Meraki
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed.type: '*device_packet_flood*'
+    string_condition_1:
+        vendorParsed.state: '*start*'
+    condition: string_condition_0 and string_condition_1
+level: info
+taxonomy: tm-v1


### PR DESCRIPTION
Add 21 Sigma detection rules for Cisco Meraki under tm-v1-sigma-rules/third_party_logs/Cisco/Meraki. Rules cover 802.1X deauth/failed auth, blocked DHCP responses, VPN/IKE Phase 1/2 establish/teardown, IPsec/ISAKMP legacy events, IDS signature matches (ingress/egress/blocked), AMP dispositions (malicious/blocked/retrospective), L3 firewall rule matches, rogue SSID/SSID spoofing, spanning-tree guard state changes, VRRP virtual router collisions, wireless packet flood detection, and VPN connectivity changes. Each rule targets THIRD_PARTY_LOG Meraki events using vendorParsed string conditions and is tagged under the tm-v1 taxonomy to improve Meraki detection coverage.