### PR TITLE
[Infoblox] New CDFs

### DIFF
--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
@@ -1,0 +1,14 @@
+title: Infoblox High Risk Event Severity
+description: Infoblox detection for high risk events. This detection is based on the presence of the "InfobloxB1FeedName" field with the value "Infoblox_High_Risk" in the vendorParsed data. This indicates that the event has been flagged as high risk by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mappingtags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"severity\":\"8\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
@@ -1,7 +1,8 @@
 title: Infoblox High Risk Event Severity
 description: Infoblox detection for high risk events. This detection is based on the presence of the "InfobloxB1FeedName" field with the value "Infoblox_High_Risk" in the vendorParsed data. This indicates that the event has been flagged as high risk by Infoblox's threat intelligence feed.
 references: 
-    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mappingtags
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
 logsource:
     category: THIRD_PARTY_LOG
     product: Infoblox

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox High Risk Event Severity.yaml
@@ -1,7 +1,7 @@
 title: Infoblox High Risk Event Severity
 description: Infoblox detection for high risk events. This detection is based on the presence of the "InfobloxB1FeedName" field with the value "Infoblox_High_Risk" in the vendorParsed data. This indicates that the event has been flagged as high risk by Infoblox's threat intelligence feed.
 references: 
-    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mappingtags: []
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mappingtags
 logsource:
     category: THIRD_PARTY_LOG
     product: Infoblox

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox Medium Risk Event Severity.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Infoblox Medium Risk Event Severity.yaml
@@ -1,0 +1,15 @@
+title: Infoblox Medium Risk Event Severity
+description: Infoblox detection for medium risk events. This detection is based on the presence of the "InfobloxB1FeedName" field with the value "Infoblox_Med_Risk" in the vendorParsed data. This indicates that the event has been flagged as medium risk by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"severity\":\"5\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Malicious Traffic Distribution System.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Malicious Traffic Distribution System.yaml
@@ -1,0 +1,15 @@
+title: Malicious Traffic Distribution System
+description: Infoblox detection for malicious traffic distribution systems.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Malicious_TDS\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Malware Download.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Malware Download.yaml
@@ -1,0 +1,15 @@
+title: Malware Download
+description: Infoblox detection for malware downloads. Detects for downloads of malware based on the presence of the "InfobloxThreatProperty" field with the value "MalwareDownload_Generic" in the vendorParsed data. This indicates that the domain has been flagged for hosting or distributing malware by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"MalwareDownload_Generic\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Generic Malicious Connection Established.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Generic Malicious Connection Established.yaml
@@ -1,0 +1,15 @@
+title: Possible Generic Malicious Connection Established 
+description: Infoblox detection for possible malicious connections. Detects connections that may be indicative of malicious activity based on the presence of the "InfobloxThreatProperty" field with the value "Malicious_Connection" in the vendorParsed data. This indicates that the domain has been flagged by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Malicious_Generic\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Generic Phishing Website Visited.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Generic Phishing Website Visited.yaml
@@ -1,0 +1,14 @@
+title: Possible Generic Phishing Website Visited 
+description: Infoblox detection for possible generic phishing website visits. Detects visits to websites that may be hosting or distributing phishing content based on the presence of the "InfobloxThreatProperty" field with the value "Phishing_Generic" in the vendorParsed data. This indicates that the domain has been flagged by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mappingtags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Phishing_Generic\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Proxy Connection Established.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Possible Proxy Connection Established.yaml
@@ -1,0 +1,15 @@
+title: Possible Proxy Connection Established
+description: Infoblox detection for possible proxy connections. Detects connections that may be indicative of proxy activity based on the presence of the "InfobloxThreatProperty" field with the value "Proxy_Connection" in the vendorParsed data. This indicates that the domain has been flagged by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Proxy_Generic\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Emergent Domain.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Emergent Domain.yaml
@@ -1,0 +1,15 @@
+title: Suspicious Emergent Domain
+description: Infoblox detection for suspicious emergent domains. This detection is based on the presence of the "InfobloxB1FeedName" field with the value "Infoblox_Med_Risk" in the vendorParsed data. This indicates that the domain has been flagged as medium risk by Infoblox's threat intelligence feed.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Suspicious_EmergentDomain\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Nameserver.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Nameserver.yaml
@@ -1,0 +1,15 @@
+title: Suspicious Nameserver
+description: Infoblox detection for suspicious nameservers.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Suspicious_Nameserver\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Traffic Distribution System.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/Infoblox/Suspicious Traffic Distribution System.yaml
@@ -1,0 +1,15 @@
+title: Suspicious Traffic Distribution System
+description: Infoblox detection for suspicious traffic distribution systems.
+references: 
+    - https://docs.infoblox.com/space/BloxOneDDI/209453743/DNS+Security+Policy+Hit+and+RPZ+Hit+Log+Message+Mapping
+tags: []
+logsource:
+    category: THIRD_PARTY_LOG
+    product: Infoblox
+    definition: THIRDPARTY_THIRDPARTY
+detection:
+    string_condition_0:
+        vendorParsed: "*\"InfobloxThreatProperty\":\"Suspicious_TDS\"*"
+    condition: string_condition_0 
+level: info
+taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server DBINFO Stack Buffer Overflow CVE-2010-4069.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server DBINFO Stack Buffer Overflow CVE-2010-4069.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054646
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server DBINFO Stack Buffer Overflow CVE-2010-4069.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server DBINFO Stack Buffer Overflow CVE-2010-4069.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054646
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server oninit.exe EXPLAIN Stack Buffer Overflow CVE-2010-4053.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server oninit.exe EXPLAIN Stack Buffer Overflow CVE-2010-4053.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054649
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server oninit.exe EXPLAIN Stack Buffer Overflow CVE-2010-4053.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DB IBM Informix Dynamic Server oninit.exe EXPLAIN Stack Buffer Overflow CVE-2010-4053.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054649
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DNS Oracle Secure Backup observiced.exe Buffer Overflow -1 CVE-2010-0072.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DNS Oracle Secure Backup observiced.exe Buffer Overflow -1 CVE-2010-0072.yaml
@@ -13,6 +13,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054180
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DNS Oracle Secure Backup observiced.exe Buffer Overflow -1 CVE-2010-0072.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DNS Oracle Secure Backup observiced.exe Buffer Overflow -1 CVE-2010-0072.yaml
@@ -13,6 +13,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054180
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS MIT Kerberos KDC NULL Pointer Denial of Service.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS MIT Kerberos KDC NULL Pointer Denial of Service.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054492
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS MIT Kerberos KDC NULL Pointer Denial of Service.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS MIT Kerberos KDC NULL Pointer Denial of Service.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054492
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS Multiple Vendors NTP Mode 7 Denial of Service CVE-2009-3563.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS Multiple Vendors NTP Mode 7 Denial of Service CVE-2009-3563.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054801
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS Multiple Vendors NTP Mode 7 Denial of Service CVE-2009-3563.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge DOS Multiple Vendors NTP Mode 7 Denial of Service CVE-2009-3563.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054801
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI Hostname Parameter Buffer Overflow CVE-2010-1555.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI Hostname Parameter Buffer Overflow CVE-2010-1555.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054539
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI Hostname Parameter Buffer Overflow CVE-2010-1555.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI Hostname Parameter Buffer Overflow CVE-2010-1555.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054539
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI ICount Parameter Buffer Overflow -1 CVE-2010-1554.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI ICount Parameter Buffer Overflow -1 CVE-2010-1554.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054542
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI ICount Parameter Buffer Overflow -1 CVE-2010-1554.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM getnnmdata.exe CGI ICount Parameter Buffer Overflow -1 CVE-2010-1554.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054542
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM ovwebsnmpsrv.exe Invalid Option Buffer Overflow CVE-2010-1960.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM ovwebsnmpsrv.exe Invalid Option Buffer Overflow CVE-2010-1960.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054556
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM ovwebsnmpsrv.exe Invalid Option Buffer Overflow CVE-2010-1960.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView NNM ovwebsnmpsrv.exe Invalid Option Buffer Overflow CVE-2010-1960.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054556
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager OvJavaLocale Buffer Overflow -1 CVE-2010-2709.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager OvJavaLocale Buffer Overflow -1 CVE-2010-2709.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054241
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager OvJavaLocale Buffer Overflow -1 CVE-2010-2709.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager OvJavaLocale Buffer Overflow -1 CVE-2010-2709.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054241
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager webappmon.exe Buffer Overflow -1 CVE-2011-3166.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager webappmon.exe Buffer Overflow -1 CVE-2011-3166.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054579
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager webappmon.exe Buffer Overflow -1 CVE-2011-3166.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network Node Manager webappmon.exe Buffer Overflow -1 CVE-2011-3166.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054579
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network nnmRptConfig.exe nameParams text1 Buffer Overflow -1.b CVE-2011-0268.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network nnmRptConfig.exe nameParams text1 Buffer Overflow -1.b CVE-2011-0268.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054471
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network nnmRptConfig.exe nameParams text1 Buffer Overflow -1.b CVE-2011-0268.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit HP OpenView Network nnmRptConfig.exe nameParams text1 Buffer Overflow -1.b CVE-2011-0268.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054471
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit MIT Kerberos KDC Ticket Validation Double Free Memory Corruption CVE-2010-1320.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit MIT Kerberos KDC Ticket Validation Double Free Memory Corruption CVE-2010-1320.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054529
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit MIT Kerberos KDC Ticket Validation Double Free Memory Corruption CVE-2010-1320.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit MIT Kerberos KDC Ticket Validation Double Free Memory Corruption CVE-2010-1320.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054529
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Address Book Insecure Library Loading Code Execution - HTTP CVE-2010-3147.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Address Book Insecure Library Loading Code Execution - HTTP CVE-2010-3147.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054938
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Address Book Insecure Library Loading Code Execution - HTTP CVE-2010-3147.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Address Book Insecure Library Loading Code Execution - HTTP CVE-2010-3147.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054938
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Silverlight Pointer Handling Memory Corruption CVE-2010-0019.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Silverlight Pointer Handling Memory Corruption CVE-2010-0019.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054583
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Silverlight Pointer Handling Memory Corruption CVE-2010-0019.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Silverlight Pointer Handling Memory Corruption CVE-2010-0019.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054583
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Windows Common Control Library Heap Buffer Overflow -1 CVE-2010-2746.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Windows Common Control Library Heap Buffer Overflow -1 CVE-2010-2746.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054566
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Windows Common Control Library Heap Buffer Overflow -1 CVE-2010-2746.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit Microsoft Windows Common Control Library Heap Buffer Overflow -1 CVE-2010-2746.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054566
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit ProZilla ftpsearch Results Handling Client-Side Buffer Overflow CVE-2005-2961.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit ProZilla ftpsearch Results Handling Client-Side Buffer Overflow CVE-2005-2961.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052176
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit ProZilla ftpsearch Results Handling Client-Side Buffer Overflow CVE-2005-2961.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit ProZilla ftpsearch Results Handling Client-Side Buffer Overflow CVE-2005-2961.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052176
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit RealNetworks Multiple Products SMIL Wallclock Stack Overflow CVE-2007-3410.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit RealNetworks Multiple Products SMIL Wallclock Stack Overflow CVE-2007-3410.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054760
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit RealNetworks Multiple Products SMIL Wallclock Stack Overflow CVE-2007-3410.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Exploit RealNetworks Multiple Products SMIL Wallclock Stack Overflow CVE-2007-3410.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054760
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Adobe Audition Session File Stack Buffer Overflow -2 CVE-2011-0614.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Adobe Audition Session File Stack Buffer Overflow -2 CVE-2011-0614.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054882
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Adobe Audition Session File Stack Buffer Overflow -2 CVE-2011-0614.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Adobe Audition Session File Stack Buffer Overflow -2 CVE-2011-0614.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054882
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Apple Quicktime MJPEG Frame stsd Atom Heap Overflow CVE-2013-1020.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Apple Quicktime MJPEG Frame stsd Atom Heap Overflow CVE-2013-1020.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054612
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Apple Quicktime MJPEG Frame stsd Atom Heap Overflow CVE-2013-1020.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FILE Apple Quicktime MJPEG Frame stsd Atom Heap Overflow CVE-2013-1020.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054612
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP Novell Netware FTP Server DELE Command Stack Buffer Overflow CVE-2010-4228.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP Novell Netware FTP Server DELE Command Stack Buffer Overflow CVE-2010-4228.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054420
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP Novell Netware FTP Server DELE Command Stack Buffer Overflow CVE-2010-4228.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP Novell Netware FTP Server DELE Command Stack Buffer Overflow CVE-2010-4228.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054420
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP RMD Command Buffer Overflow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP RMD Command Buffer Overflow.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054452
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP RMD Command Buffer Overflow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge FTP RMD Command Buffer Overflow.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054452
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge ICS VULN IntelliCom NetBiter Config Utility Hostname Stack Buffer Overflow CVE-2009-4462.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge ICS VULN IntelliCom NetBiter Config Utility Hostname Stack Buffer Overflow CVE-2009-4462.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054800
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge ICS VULN IntelliCom NetBiter Config Utility Hostname Stack Buffer Overflow CVE-2009-4462.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge ICS VULN IntelliCom NetBiter Config Utility Hostname Stack Buffer Overflow CVE-2009-4462.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054800
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge LDAP IBM Lotus Domino LDAP Heap Buffer Overflow -2 CVE-2010-0358.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge LDAP IBM Lotus Domino LDAP Heap Buffer Overflow -2 CVE-2010-0358.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054494
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge LDAP IBM Lotus Domino LDAP Heap Buffer Overflow -2 CVE-2010-0358.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge LDAP IBM Lotus Domino LDAP Heap Buffer Overflow -2 CVE-2010-0358.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054494
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RDP Microsoft Windows Remote Desktop Protocol Denial of Service CVE-2005-1218.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RDP Microsoft Windows Remote Desktop Protocol Denial of Service CVE-2005-1218.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052115
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RDP Microsoft Windows Remote Desktop Protocol Denial of Service CVE-2005-1218.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RDP Microsoft Windows Remote Desktop Protocol Denial of Service CVE-2005-1218.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052115
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RPC MIT Kerberos kadmind RPC Library Unix Authentication Buffer Overflow -2 CVE-2007-2443.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RPC MIT Kerberos kadmind RPC Library Unix Authentication Buffer Overflow -2 CVE-2007-2443.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054735
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RPC MIT Kerberos kadmind RPC Library Unix Authentication Buffer Overflow -2 CVE-2007-2443.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge RPC MIT Kerberos kadmind RPC Library Unix Authentication Buffer Overflow -2 CVE-2007-2443.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054735
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Adobe Shockwave Director File Key Chunk Parsing Buffer Overflow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Adobe Shockwave Director File Key Chunk Parsing Buffer Overflow.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054884
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Adobe Shockwave Director File Key Chunk Parsing Buffer Overflow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Adobe Shockwave Director File Key Chunk Parsing Buffer Overflow.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054884
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Cisco Network Registrar Default Credentials Authentication Bypass.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Cisco Network Registrar Default Credentials Authentication Bypass.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054901
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Cisco Network Registrar Default Credentials Authentication Bypass.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge VULN Cisco Network Registrar Default Credentials Authentication Bypass.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054901
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Apache HTTP Server Byte-Range DoS CVE-2011-3192.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Apache HTTP Server Byte-Range DoS CVE-2011-3192.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054963
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Apache HTTP Server Byte-Range DoS CVE-2011-3192.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Apache HTTP Server Byte-Range DoS CVE-2011-3192.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054963
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS Multiple Report Stored Procedure SQL Injections CVE-2011-1653.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS Multiple Report Stored Procedure SQL Injections CVE-2011-1653.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054896
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS Multiple Report Stored Procedure SQL Injections CVE-2011-1653.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS Multiple Report Stored Procedure SQL Injections CVE-2011-1653.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054896
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS UnassignFunctionalRoles Stored Procedure SQL Injection.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS UnassignFunctionalRoles Stored Procedure SQL Injection.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054858
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS UnassignFunctionalRoles Stored Procedure SQL Injection.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web CA Total Defense Suite UNCWS UnassignFunctionalRoles Stored Procedure SQL Injection.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054858
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Cisco Unified Communications Manager Multiple SQL Injections.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Cisco Unified Communications Manager Multiple SQL Injections.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054898
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Cisco Unified Communications Manager Multiple SQL Injections.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Cisco Unified Communications Manager Multiple SQL Injections.yaml
@@ -9,6 +9,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054898
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager OvWebHelp.exe Buffer Overflow CVE-2009-4178.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager OvWebHelp.exe Buffer Overflow CVE-2009-4178.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054802
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager OvWebHelp.exe Buffer Overflow CVE-2009-4178.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager OvWebHelp.exe Buffer Overflow CVE-2009-4178.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054802
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager nnmRptConfig.exe Template Buffer Overflow CVE-2009-3848.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager nnmRptConfig.exe Template Buffer Overflow CVE-2009-3848.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054806
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager nnmRptConfig.exe Template Buffer Overflow CVE-2009-3848.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager nnmRptConfig.exe Template Buffer Overflow CVE-2009-3848.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054806
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager ovsessionmgr.exe Buffer Overflow CVE-2009-4176.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager ovsessionmgr.exe Buffer Overflow CVE-2009-4176.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054795
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager ovsessionmgr.exe Buffer Overflow CVE-2009-4176.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager ovsessionmgr.exe Buffer Overflow CVE-2009-4176.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054795
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager snmp.exe Oid Variable Buffer Overflow CVE-2009-3849.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager snmp.exe Oid Variable Buffer Overflow CVE-2009-3849.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054807
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager snmp.exe Oid Variable Buffer Overflow CVE-2009-3849.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP OpenView Network Node Manager snmp.exe Oid Variable Buffer Overflow CVE-2009-3849.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054807
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP Power Manager Administration Web Server Stack Buffer Overflow CVE-2010-4113.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP Power Manager Administration Web Server Stack Buffer Overflow CVE-2010-4113.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054558
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP Power Manager Administration Web Server Stack Buffer Overflow CVE-2010-4113.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web HP Power Manager Administration Web Server Stack Buffer Overflow CVE-2010-4113.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054558
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Backup Manager Insecure Library Loading Code Execution -1 CVE-2010-3145.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Backup Manager Insecure Library Loading Code Execution -1 CVE-2010-3145.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054326
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Backup Manager Insecure Library Loading Code Execution -1 CVE-2010-3145.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Backup Manager Insecure Library Loading Code Execution -1 CVE-2010-3145.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054326
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Web Services on Devices API Memory Corruption -1 CVE-2009-2512.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Web Services on Devices API Memory Corruption -1 CVE-2009-2512.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054769
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Web Services on Devices API Memory Corruption -1 CVE-2009-2512.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Microsoft Windows Web Services on Devices API Memory Corruption -1 CVE-2009-2512.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054769
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java IE Browser Plugin docbase Parameter Stack Buffer Overflow -1 CVE-2010-3552 Possible Exploit Kit.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java IE Browser Plugin docbase Parameter Stack Buffer Overflow -1 CVE-2010-3552 Possible Exploit Kit.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054629
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java IE Browser Plugin docbase Parameter Stack Buffer Overflow -1 CVE-2010-3552 Possible Exploit Kit.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java IE Browser Plugin docbase Parameter Stack Buffer Overflow -1 CVE-2010-3552 Possible Exploit Kit.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054629
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java Web Start Launch Command-Line Injection -1 CVE-2010-1423.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java Web Start Launch Command-Line Injection -1 CVE-2010-1423.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054524
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java Web Start Launch Command-Line Injection -1 CVE-2010-1423.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Oracle Java Web Start Launch Command-Line Injection -1 CVE-2010-1423.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054524
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web SQL Injection Attempt -23.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web SQL Injection Attempt -23.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054870
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web SQL Injection Attempt -23.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web SQL Injection Attempt -23.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054870
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager Administrative Interface SQL Injections CVE-2010-0112.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager Administrative Interface SQL Injections CVE-2010-0112.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054656
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager Administrative Interface SQL Injections CVE-2010-0112.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager Administrative Interface SQL Injections CVE-2010-0112.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054656
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager IMAdminReportTrendFormRun.asp SQL Injection CVE-2010-0112.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager IMAdminReportTrendFormRun.asp SQL Injection CVE-2010-0112.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054655
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager IMAdminReportTrendFormRun.asp SQL Injection CVE-2010-0112.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web Symantec IM Manager IMAdminReportTrendFormRun.asp SQL Injection CVE-2010-0112.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054655
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Active Template Library Uninitialized Object Code Execution -2 CVE-2009-0901.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Active Template Library Uninitialized Object Code Execution -2 CVE-2009-0901.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054680
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Active Template Library Uninitialized Object Code Execution -2 CVE-2009-0901.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Active Template Library Uninitialized Object Code Execution -2 CVE-2009-0901.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054680
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Core XML Core Services XMLHTTP Control Open Method Code Execution CVE-2006-5745.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Core XML Core Services XMLHTTP Control Open Method Code Execution CVE-2006-5745.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054083
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Core XML Core Services XMLHTTP Control Open Method Code Execution CVE-2006-5745.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Core XML Core Services XMLHTTP Control Open Method Code Execution CVE-2006-5745.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054083
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Office Web Components ActiveX Control Remote Code Execution -1 CVE-2009-1534 state 1-F-Flow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Office Web Components ActiveX Control Remote Code Execution -1 CVE-2009-1534 state 1-F-Flow.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054694
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Office Web Components ActiveX Control Remote Code Execution -1 CVE-2009-1534 state 1-F-Flow.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Office Web Components ActiveX Control Remote Code Execution -1 CVE-2009-1534 state 1-F-Flow.yaml
@@ -11,6 +11,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054694
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Remote Desktop ActiveX Control Heap Overflow CVE-2009-1929.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Remote Desktop ActiveX Control Heap Overflow CVE-2009-1929.yaml
@@ -15,6 +15,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054695
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Remote Desktop ActiveX Control Heap Overflow CVE-2009-1929.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Microsoft Remote Desktop ActiveX Control Heap Overflow CVE-2009-1929.yaml
@@ -15,6 +15,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054695
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Oracle Document Capture ActiveX Control WriteJPG Buffer Overflow -1 CVE-2010-3599.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Oracle Document Capture ActiveX Control WriteJPG Buffer Overflow -1 CVE-2010-3599.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054818
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Oracle Document Capture ActiveX Control WriteJPG Buffer Overflow -1 CVE-2010-3599.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX Oracle Document Capture ActiveX Control WriteJPG Buffer Overflow -1 CVE-2010-3599.yaml
@@ -12,6 +12,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054818
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX SAP Crystal Reports PrintControl.dll ActiveX Control Buffer Overflow CVE-2010-2590.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX SAP Crystal Reports PrintControl.dll ActiveX Control Buffer Overflow CVE-2010-2590.yaml
@@ -13,6 +13,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054576
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX SAP Crystal Reports PrintControl.dll ActiveX Control Buffer Overflow CVE-2010-2590.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX SAP Crystal Reports PrintControl.dll ActiveX Control Buffer Overflow CVE-2010-2590.yaml
@@ -13,6 +13,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1054576
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX WMI Object Broker ActiveX Control Execution CVE-2006-4704.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX WMI Object Broker ActiveX Control Execution CVE-2006-4704.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052712
-  condition: mappingtable
+  condition: selection and mappingtable
 level: info
 taxonomy: tm-v1

--- a/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX WMI Object Broker ActiveX Control Execution CVE-2006-4704.yaml
+++ b/tm-v1-sigma-rules/third_party_logs/TXOne Networks/TXOne Networks/Firewall/TLC-Edge Web-ActiveX WMI Object Broker ActiveX Control Execution CVE-2006-4704.yaml
@@ -10,6 +10,6 @@ logsource:
 detection:
   mappingtable:
     ruleId: 1052712
-  condition: selection and mappingtable
+  condition: mappingtable
 level: info
 taxonomy: tm-v1


### PR DESCRIPTION
Add 10 new CDF under tm-v1-sigma-rules/third_party_logs/Infoblox to detect Infoblox threat-intel hits. Each rule matches vendorParsed content (InfobloxThreatProperty values or severity fields) to surface events such as MalwareDownload, Malicious_TDS, Phishing_Generic, Proxy_Generic, Suspicious_Nameserver/EmergentDomain/TDS, and high/medium risk severities. Rules target THIRD_PARTY_LOG product Infoblox, use level: info and taxonomy: tm-v1 to capture vendor-flagged detections.